### PR TITLE
Fix Text receiveShadow setting

### DIFF
--- a/src/core/MRTextEntity.js
+++ b/src/core/MRTextEntity.js
@@ -23,7 +23,7 @@ export class MRTextEntity extends MRDivEntity {
         this.object3D.name = 'textObj';
         this.editable = false;
 
-        this.textObj.material.receiveShadow = true;
+        this.textObj.receiveShadow = true;
 
         // This event listener is added so anytime a panel changes (resize, etc), the text changes
         // accordingly


### PR DESCRIPTION
[Three.js `Object3D` has `.receiveShadow` property](https://threejs.org/docs/#api/en/core/Object3D.receiveShadow) but `Material` doesn't. `.receiveShadow = true` should be set for text object, not text object's material.