### PR TITLE
Introduce stats attribute to mr-app

### DIFF
--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -214,11 +214,15 @@ export class MRApp extends MRElement {
             }
         }
 
-        if (this.debug) {
+        const statsEnabled = this.getAttribute('stats');
+
+        if (statsEnabled) {
             this.stats = new Stats();
             this.stats.showPanel(0); // 0: fps, 1: ms, 2: mb, 3+: custom
             document.body.appendChild(this.stats.dom);
+        }
 
+        if (this.debug) {
             const orbitControls = new OrbitControls(this.camera, this.renderer.domElement);
             orbitControls.minDistance = 1;
             orbitControls.maxDistance = 2;


### PR DESCRIPTION
From https://github.com/Volumetrics-io/mrjs/issues/441#issuecomment-1958902374 and the following comments.

**Problem**

Stats panel is useful to check the runtime performance and memory consumption. Currently it's enabled if mr-app debug mode. But in debug mode there are many overheads for helping debug and they may be costly. We don't have a way to check the stats in production mode.

**Change for solution**

Separate stats panel from debug mode amd introduce a new stats attribute to mr-app.

Stats panel will be enabled by setting stats attribute like `<mr-app stats="true">`.

This change allows to enable stats in production mode.

**Breaking change**

Stats panel will no longer be enabled just with debug mode like `<mr-app debug="true">`. You need to explicitly add stats attribute if you want to enable it in debug mode like `<mr-app debug="true" stats="true">`.

**Note**

Stats support in immersive mode will be in another PR, not in this PR.