### PR TITLE
More appropriate Stats update

### DIFF
--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -441,6 +441,12 @@ export class MRApp extends MRElement {
 
         const deltaTime = this.clock.getDelta();
 
+        // ----- Update stats if enabled ----- //
+
+        if (this.stats) {
+            this.stats.update();
+        }
+
         // ----- Update needed items ----- //
 
         if (mrjsUtils.xr.isPresenting && !mrjsUtils.xr.session) {
@@ -465,14 +471,8 @@ export class MRApp extends MRElement {
 
         // ----- System Updates ----- //
 
-        if (this.debug) {
-            this.stats.begin();
-        }
         for (const system of this.systems) {
             system._update(deltaTime, frame);
-        }
-        if (this.debug) {
-            this.stats.end();
         }
 
         // ----- Actually Render ----- //


### PR DESCRIPTION
From: https://github.com/Volumetrics-io/mrjs/issues/441#issuecomment-1960628809

**Problem**

Currently we call `stats.begin()` and `.end()` before and after systems update, like

```
stats.begin();
for (const system of systems) {
    system._update(deltaTime, frame);
}
stats.end();
```

But about calculating FPS number, it may just check the CPU time elapsed by the systems. It may not precisely monitor the elapsed time, for example it may ignore GPU busy time, for calculating FPS number that should represent the performance between animation frames.

**Change for solution**

Use `stats.update()` and call it once in an animation loop. It looks like be more aligned with appropriate Stats API to check the FPS.

In [the Three.js official examples](https://threejs.org/examples/) you will find this style in many examples.