### PR TITLE
Fix clipping targets

### DIFF
--- a/src/core/MREntity.js
+++ b/src/core/MREntity.js
@@ -52,6 +52,7 @@ export class MREntity extends MRElement {
         });
 
         this.object3D = new THREE.Group();
+        this.object3D.userData.isEntityObject3DRoot = true;
         this.object3D.userData.bbox = new THREE.Box3();
         this.object3D.userData.size = new THREE.Vector3();
 


### PR DESCRIPTION
**Problem**

Clipping system is designed to apply the clipping only the entities that are not masking system targets as optimization. But currently due to a bug the entities that are masking system targets can be also the targets of the clipping system.

This problem can cause a bad performance impact because clippings are done more than needed.

**Change for solution**

Fix the bug.

In the change for the bug fix, introducing `Object3D.userData.isEntityObject3DRoot` to distinguish whether an Three.js `Object3D` is a root `Object3D` of MR entity to handle clipping targets properly.

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
