### PR TITLE
add the missing testing example links to main examples page

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -51,11 +51,20 @@
           <mr-a class="example-link" href="https://examples.mrjs.io/examples/embed.html">
             Embed
           </mr-a>
+          <mr-a class="example-link" href="https://examples.mrjs.io/examples/images.html">
+            Images
+          </mr-a>
           <mr-a class="example-link" href="https://examples.mrjs.io/examples/models.html">
             Models
           </mr-a>
+          <mr-a class="example-link" href="https://examples.mrjs.io/examples/panels.html">
+            Panels
+          </mr-a>
           <mr-a class="example-link" href="https://examples.mrjs.io/examples/skybox.html">
             Skybox
+          </mr-a>
+           <mr-a class="example-link" href="https://examples.mrjs.io/examples/video.html">
+            Video
           </mr-a>
         </mr-div>
         


### PR DESCRIPTION
## Problem

Our examples page in testing had gotten out of date - it was missing some of the more recent examples

## Solution

added the missing items

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
~~- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected~~
~~- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.~~
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
~~- [ ] **BREAKING CHANGE**~~
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
