### PR TITLE
Optimize Clipping system

### DIFF
--- a/src/core/componentSystems/ClippingSystem.js
+++ b/src/core/componentSystems/ClippingSystem.js
@@ -6,6 +6,8 @@ import { MREntity } from 'mrjs/core/MREntity';
 import { MRClippingGeometry } from 'mrjs/dataTypes/MRClippingGeometry';
 import { MRVolume } from '../entities/MRVolume';
 
+const PLANE_NUM = 6;
+
 /**
  * @class ClippingSystem
  * @classdesc   This system supports 3D clipping following threejs's clipping planes setup.
@@ -25,8 +27,6 @@ export class ClippingSystem extends MRSystem {
         this.coplanarPointA = new THREE.Vector3();
         this.coplanarPointB = new THREE.Vector3();
         this.coplanarPointC = new THREE.Vector3();
-        // The plane geometry.
-        this.geometry = new THREE.BufferGeometry();
     }
 
     /**
@@ -67,18 +67,21 @@ export class ClippingSystem extends MRSystem {
      * @param {MREntity} entity - given entity that will be used to create the clipping planes positioning.
      */
     updatePlanes(entity) {
-        this.geometry = entity.clipping.geometry.toNonIndexed();
-        let geoPositionArray = this.geometry.attributes.position.array;
+        // clipping.geometry is one segment BoxGeometry. See MRClippingGeometry.
 
-        let planeIndex = 0;
-        for (let f = 0; f < this.geometry.attributes.position.count * 3; f += 9) {
-            if (!entity.clipping.planeIDs.includes(f)) {
-                continue;
-            }
+        const geometry = entity.clipping.geometry;
+        const positions = geometry.getAttribute('position').array;
+        const indices = geometry.getIndex().array;
 
-            this.coplanarPointA.set(-geoPositionArray[f], -geoPositionArray[f + 1], -geoPositionArray[f + 2]);
-            this.coplanarPointB.set(-geoPositionArray[f + 3], -geoPositionArray[f + 4], -geoPositionArray[f + 5]);
-            this.coplanarPointC.set(-geoPositionArray[f + 6], -geoPositionArray[f + 7], -geoPositionArray[f + 8]);
+        for (let i = 0; i < PLANE_NUM; i++) {
+            const indexOffset = i * 6;
+            const positionIndexA = indices[indexOffset] * 3;
+            const positionIndexB = indices[indexOffset + 1] * 3;
+            const positionIndexC = indices[indexOffset + 2] * 3;
+
+            this.coplanarPointA.set(-positions[positionIndexA], -positions[positionIndexA + 1], -positions[positionIndexA + 2]);
+            this.coplanarPointB.set(-positions[positionIndexB], -positions[positionIndexB + 1], -positions[positionIndexB + 2]);
+            this.coplanarPointC.set(-positions[positionIndexC], -positions[positionIndexC + 1], -positions[positionIndexC + 2]);
 
             if (entity instanceof MRVolume) {
                 entity.volume.localToWorld(this.coplanarPointA);
@@ -90,8 +93,7 @@ export class ClippingSystem extends MRSystem {
                 entity.panel.localToWorld(this.coplanarPointC);
             }
 
-            entity.clipping.planes[planeIndex].setFromCoplanarPoints(this.coplanarPointA, this.coplanarPointB, this.coplanarPointC);
-            planeIndex += 1;
+            entity.clipping.planes[i].setFromCoplanarPoints(this.coplanarPointA, this.coplanarPointB, this.coplanarPointC);
         }
     }
 
@@ -116,34 +118,17 @@ export class ClippingSystem extends MRSystem {
      * @param {MREntity} entity - the entity to which we're adding the clipping planes information
      */
     addClippingPlanes(entity) {
-        this.geometry = entity.clipping.geometry.toNonIndexed();
-        let geoPositionArray = this.geometry.attributes.position.array;
-
-        for (let f = 0; f < this.geometry.attributes.position.count * 3; f += 9) {
-            this.coplanarPointA.set(-geoPositionArray[f], -geoPositionArray[f + 1], -geoPositionArray[f + 2]);
-            this.coplanarPointB.set(-geoPositionArray[f + 3], -geoPositionArray[f + 4], -geoPositionArray[f + 5]);
-            this.coplanarPointC.set(-geoPositionArray[f + 6], -geoPositionArray[f + 7], -geoPositionArray[f + 8]);
-
-            if (entity instanceof MRVolume) {
-                entity.volume.localToWorld(this.coplanarPointA);
-                entity.volume.localToWorld(this.coplanarPointB);
-                entity.volume.localToWorld(this.coplanarPointC);
-            } else {
-                entity.panel.localToWorld(this.coplanarPointA);
-                entity.panel.localToWorld(this.coplanarPointB);
-                entity.panel.localToWorld(this.coplanarPointC);
-            }
-
+        for (let i = 0; i < PLANE_NUM; i++) {
             const newPlane = new THREE.Plane();
-            newPlane.setFromCoplanarPoints(this.coplanarPointA, this.coplanarPointB, this.coplanarPointC);
+
             // if (this.app.debug) {
             //     const helper = new THREE.PlaneHelper( newPlane, 1, 0xff00ff );
             //     this.app.scene.add( helper );
             // }
 
             entity.clipping.planes.push(newPlane);
-            entity.clipping.planeIDs.push(f);
         }
+        this.updatePlanes(entity);
     }
 
     /**

--- a/src/dataTypes/MRClippingGeometry.js
+++ b/src/dataTypes/MRClippingGeometry.js
@@ -5,8 +5,6 @@
 export class MRClippingGeometry {
     planes = [];
 
-    planeIDs = [];
-
     intersection = false;
 
     global = false;
@@ -22,6 +20,17 @@ export class MRClippingGeometry {
      * @param {object} geometry - The geometry to be captured internally by `this.geometry`.
      */
     constructor(geometry) {
+        // Limits to one segment BoxGeometry instance like created with
+        // "new BoxGeometry(width, height, depth);" for simplicity for now.
+
+        // The geometry type limitation may not be immediately obvious to users of this module.
+        // If unsupported geometry is passed, no errors may be raised, but the behavior may
+        // become erratic, and such bugs can be difficult to investigate. This check is in
+        // place to avoid such unnecessary effort.
+        if (geometry.type !== 'BoxGeometry' || geometry.parameters?.widthSegments !== 1 || geometry.parameters?.heightSegments !== 1 || geometry.parameters?.depthSegments !== 1) {
+            throw new Error('Unsupported Clipping geometry type.');
+        }
+
         this.geometry = geometry;
     }
 }


### PR DESCRIPTION
## Linking

Fixes #466

## Problem

Currently clipping system is a bit more inefficient because it assigns 12 panels to an entity although 6 panels may be good enough and it unnecessarily creates a new `BufferGeometry` in `update()`.

## Changes for solution

Optimize and clean up.

- Assigns 6 panels to an entity
- Avoid new `BufferGeometry` creation in `update()`
- Remove some duplicated codes

## Breaking changes

Limiting `clipping.geometry` to one segment `BoxGeometry` for simplicity.

@michaelthatsit 

The current implementation seems that support for complex ClippingGeometry shapes is also being considered. However, there are also some codes that seem to assume BoxGeometry. In this PR, I would like to propose changing the specification to assume BoxGeometry for simplicity for now. Introducing complex shape and logic makes it easier for bugs to creep in, such as in the case of 12 planes. We can consider how to support for complex shapes in the future. I believe that keeping things simple will also make it easier to make improvements in the future.

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
