### PR TITLE
Fix Masking System

### DIFF
--- a/src/core/MREntity.js
+++ b/src/core/MREntity.js
@@ -420,6 +420,23 @@ export class MREntity extends MRElement {
             child.traverse(callBack);
         }
     }
+
+    /**
+     * @function
+     * @description Runs the passed through function on the objects associated with this Entity
+     * @param {Function} callBack - the function to run recursively.
+     */
+    traverseObjects(callBack) {
+        const traverse = (object) => {
+            callBack(object);
+            for (const child of object.children) {
+                if (!child.userData.isEntityObject3DRoot) {
+                    traverse(child);
+                }
+            }
+        };
+        traverse(this.object3D);
+    }
 }
 
 customElements.get('mr-entity') || customElements.define('mr-entity', MREntity);

--- a/src/core/componentSystems/ClippingSystem.js
+++ b/src/core/componentSystems/ClippingSystem.js
@@ -91,18 +91,12 @@ export class ClippingSystem extends MRSystem {
             return;
         }
 
-        const traverse = (object) => {
+        entity.traverseObjects((object) => {
             if (object.isMesh) {
                 object.material.clippingPlanes = clipping.planes;
                 object.material.clipIntersection = clipping.intersection;
             }
-            for (const child of object.children) {
-                if (!child.userData.isEntityObject3DRoot) {
-                    traverse(child);
-                }
-            }
-        };
-        traverse(entity.object3D);
+        });
     }
 
     /**

--- a/src/core/componentSystems/MaskingSystem.js
+++ b/src/core/componentSystems/MaskingSystem.js
@@ -184,16 +184,11 @@ export class MaskingSystem extends MRSystem {
                     //
                     // Since we're stepping through every child, we only need to touch each mesh's material instead of
                     // updating group objects as a whole.
-                    if (!child.object3D.isGroup) {
-                        setupMaskedMaterial(child.object3D.material, stencilRefShift);
-                    }
-
-                    // XXX - This is a temporary fix, there's a more general solution here using entity.object3D.traverse
-                    // rather than entity.traverse, but we'd also need to move entity.ignoreStencil from entity,
-                    // to entity.object3D.userData.ignoreStencil
-                    if (child instanceof MRTextEntity) {
-                        setupMaskedMaterial(child.textObj.material, stencilRefShift);
-                    }
+                    child.traverseObjects((object) => {
+                        if (object.isMesh) {
+                            setupMaskedMaterial(object.material, stencilRefShift);
+                        }
+                    });
                 }
             });
         }

--- a/src/core/componentSystems/MaskingSystem.js
+++ b/src/core/componentSystems/MaskingSystem.js
@@ -74,9 +74,9 @@ const setupMaskingMaterial = (material, shiftBit, debug = false) => {
  */
 const setupMaskedMaterial = (material, shiftBit) => {
     material.stencilWrite = true;
-    material.stencilRef = 1 << shiftBit;
+    material.stencilRef |= 1 << shiftBit;
     material.stencilFunc = THREE.EqualStencilFunc;
-    material.stencilFuncMask = 1 << shiftBit;
+    material.stencilFuncMask |= 1 << shiftBit;
     material.stencilFail = THREE.KeepStencilOp;
     material.stencilZFail = THREE.KeepStencilOp;
     material.stencilZPass = THREE.KeepStencilOp;
@@ -100,7 +100,8 @@ export class MaskingSystem extends MRSystem {
         this.scene.matrixWorldAutoUpdate = false;
 
         this.sourceElementMap = new Map();
-        this.panelCount = 0;
+        this.maskingMeshMap = new Map();
+        this.panels = [];
     }
 
     /**
@@ -148,36 +149,41 @@ export class MaskingSystem extends MRSystem {
      */
     onNewEntity(entity) {
         if (entity instanceof MRPanel) {
-            if (this.panelCount >= MAX_PANEL_NUM) {
+            if (this.panels.length >= MAX_PANEL_NUM) {
                 console.warn('Masking system supports up to eight panels.');
                 return;
             }
 
             // Ignoring panel removal for now.
             // TODO: Handle panel removal
-            const stencilRefShift = this.panelCount;
-            this.panelCount++;
+            const stencilRefShift = this.panels.length;
+            this.panels.push(entity);
 
+            // We need to mask based off the background mesh of this object.
+            const sourceObj = entity.background;
+
+            // TODO: Optimize material.
+            // Since only needs to write to the stencil buffer, no need to write to the color buffer,
+            // therefore, we can use a simpler material than MeshBasicMaterial. Should we use
+            // ShaderMaterial?
+            const mesh = new THREE.Mesh(sourceObj.geometry, new THREE.MeshBasicMaterial());
+            setupMaskingMaterial(mesh.material, stencilRefShift, this.app.debug);
+
+            // No automatic matrices update because world matrices are updated in sync().
+            mesh.matrixAutoUpdate = false;
+            mesh.matrixWorldAutoUpdate = false;
+
+            this.scene.add(mesh);
+            this.sourceElementMap.set(mesh, entity);
+            this.maskingMeshMap.set(entity, mesh);
+
+            // Child elements are masked by this panel so traverse children and set up their materials for stencil
             entity.traverse((child) => {
-                if (child instanceof MRPanel && child.object3D.isGroup) {
-                    // The panel entity should contain a group object where the first panel child we hit is this panel itself.
-                    // We need to mask based off the background mesh of this object.
-                    const sourceObj = child.background;
+                if (entity === child) {
+                    return;
+                }
 
-                    // TODO: Optimize material.
-                    // Since only needs to write to the stencil buffer, no need to write to the color buffer,
-                    // therefore, we can use a simpler material than MeshBasicMaterial. Should we use
-                    // ShaderMaterial?
-                    const mesh = new THREE.Mesh(sourceObj.geometry, new THREE.MeshBasicMaterial());
-                    setupMaskingMaterial(mesh.material, stencilRefShift, this.app.debug);
-
-                    // No automatic matrices update because world matrices are updated in sync().
-                    mesh.matrixAutoUpdate = false;
-                    mesh.matrixWorldAutoUpdate = false;
-
-                    this.scene.add(mesh);
-                    this.sourceElementMap.set(mesh, child);
-                } else if (child instanceof MRDivEntity && !(child instanceof MRPanel) && !child.ignoreStencil) {
+                if (child instanceof MRDivEntity && !child.ignoreStencil) {
                     // The children we want to mask by the panel should only be DivEntities (ie UI elements). Other items
                     // will be clipped by the panel instead. Additionally, we want to allow for items (such as 3D elements)
                     // to be manually excluded from this masking by default or manual addition.
@@ -191,6 +197,22 @@ export class MaskingSystem extends MRSystem {
                     });
                 }
             });
+        } else if (entity instanceof MRDivEntity && !entity.ignoreStencil) {
+            // There is a chance that a child entity is added after parent panel addition.
+            // Check registered panels and set up the material if panels are found in parents.
+            for (const panel of this.panels) {
+                if (panel.contains(entity)) {
+                    const mesh = this.maskingMeshMap.get(panel);
+                    const stencilRefShift = this.panels.indexOf(panel);
+                    entity.traverseObjects((object) => {
+                        if (object.isMesh) {
+                            // setupMaskedMaterial is a very light function so
+                            // calling again for materials already set up should not be a big deal
+                            setupMaskedMaterial(object.material, stencilRefShift);
+                        }
+                    });
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Linking

Fixes #505
Fixes #509

## Problems

Problem 1:

Perhaps due to the recent changes to mapping and clipping systems, background of mr div entities seem not to be masked.

The root issue seems to be in masking system. Child objects associated with an entity need to be masked but we have been missing to set up their materials for stencil.

Problem 2:

There seems to be a race condition. Sometimes children of panels are not masked.

## Change for fix

Fix for the problem 1:

Traverse the objects associated with an entity and set up their materials.

This commit introduces a new `traverseObjects` method to `MREntity` that runs the passed through function on the objects associated with an entity as a helper method because such traversal is needed in masking and clipping systems, and it would be used from more many places in the future.

Fix for the problem 2:

Take into account that a child entity of panel can be added after parent panels are registered in masking system. Check whether there are panels in parents and set up material for stencil if there are, similar to what clipping system does.

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
