### PR TITLE
MRStats: Stats panel in immersive mode

### DIFF
--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -25,6 +25,7 @@ import { SkyBoxSystem } from 'mrjs/core/componentSystems/SkyBoxSystem';
 import { TextSystem } from 'mrjs/core/componentSystems/TextSystem';
 import { AudioSystem } from 'mrjs/core/componentSystems/AudioSystem';
 import { PanelSystem } from 'mrjs/core/componentSystems/PanelSystem';
+import { StatsSystem } from 'mrjs/core/componentSystems/StatsSystem';
 import MRUser from 'mrjs/core/user/MRUser';
 
 ('use strict');
@@ -113,7 +114,15 @@ export class MRApp extends MRElement {
         this.observer = new MutationObserver(this.mutationCallback);
         this.observer.observe(this, { attributes: true, childList: true });
 
+        if (this.getAttribute('stats')) {
+            const statsEl = document.createElement('mr-stats');
+            statsEl.setAttribute('data-comp-anchor', 'type: plane; label: wall;');
+            statsEl.setAttribute('data-position', '0 0.2 0.01');
+            this.appendChild(statsEl);
+        }
+
         // order matters for all the below system creation items
+        this.statsSystem = new StatsSystem();
         this.panelSystem = new PanelSystem();
         this.layoutSystem = new LayoutSystem();
         this.textSystem = new TextSystem();
@@ -213,14 +222,6 @@ export class MRApp extends MRElement {
             for (const layer of this.layers) {
                 this.camera.layers.enable(layer);
             }
-        }
-
-        const statsEnabled = this.getAttribute('stats');
-
-        if (statsEnabled) {
-            this.stats = new Stats();
-            this.stats.showPanel(0); // 0: fps, 1: ms, 2: mb, 3+: custom
-            document.body.appendChild(this.stats.dom);
         }
 
         if (this.debug) {
@@ -446,12 +447,6 @@ export class MRApp extends MRElement {
         // ----- grab important vars ----- //
 
         const deltaTime = this.clock.getDelta();
-
-        // ----- Update stats if enabled ----- //
-
-        if (this.stats) {
-            this.stats.update();
-        }
 
         // ----- Update needed items ----- //
 

--- a/src/core/componentSystems/StatsSystem.js
+++ b/src/core/componentSystems/StatsSystem.js
@@ -1,0 +1,59 @@
+import { mrjsUtils } from 'mrjs';
+import { MRSystem } from 'mrjs/core/MRSystem';
+import { MRStats } from 'mrjs/core/entities/MRStats';
+
+import Stats from 'stats.js';
+
+import { HTMLMesh } from 'three/addons/interactive/HTMLMesh.js';
+import { InteractiveGroup } from 'three/addons/interactive/InteractiveGroup.js';
+
+// TODO: JSDoc
+
+export class StatsSystem extends MRSystem {
+    constructor() {
+        super(false);
+        this.statsEntities = [];
+    }
+
+    update() {
+        for (const entity of this.statsEntities) {
+            if (entity.stats === null && this.app) {
+                entity.stats = new Stats();
+                entity.stats.showPanel(0); // 0: fps, 1: ms, 2: mb, 3+: custom
+                document.body.appendChild(entity.stats.dom);
+
+                // Note: InteractiveGroup API is refactored in the newer Three.js rev.
+                //       Don't forget to update the followings when upgrading Three.js
+                entity.interactiveGroup = new InteractiveGroup(this.app.renderer, this.app.camera);
+                entity.object3D.add(entity.interactiveGroup);
+
+                // Note: HTMLMesh seems to have a bug that image is not displayed at a correct position.
+                //       in Three.js r161 or older.
+                // TODO: Upgrade Three.js to fix
+
+                // Question: Circle pointer doesn't seem to be displayed on the Stats panel object
+                //           and the clickable area seems to be a difference place from the panel object, why?
+                // TODO: Fix it
+                entity.statsMesh = new HTMLMesh(entity.stats.dom);
+                entity.interactiveGroup.add(entity.statsMesh);
+            }
+
+            if (entity.stats) {
+                entity.stats.update();
+                if (mrjsUtils.xr.isPresenting) {
+                    entity.statsMesh.visible = true;
+                    entity.statsMesh.material.map.update();
+                } else {
+                    entity.statsMesh.visible = false;
+                }
+            }
+        }
+    }
+
+    onNewEntity(entity) {
+        // Question: How can we detect the removal of entities?
+        if (entity instanceof MRStats) {
+            this.statsEntities.push(entity);
+        }
+    }
+}

--- a/src/core/entities/MRStats.js
+++ b/src/core/entities/MRStats.js
@@ -1,0 +1,20 @@
+import { MRDivEntity } from '../MRDivEntity';
+
+// TODO: JSDoc
+
+export class MRStats extends MRDivEntity {
+    constructor() {
+        super();
+        this.ignoreStencil = true;
+        this.object3D.name = 'stats';
+
+        // Three.js InteractiveGroup has a dependency with WebGLRenderer and Camera
+        // instances but they can't be accessed from here so these objects are initialized
+        // in StatsSystem instead.
+        this.stats = null;
+        this.interactiveGroup = null;
+        this.statsMesh = null;
+    }
+}
+
+customElements.get('mr-stats') || customElements.define('mr-stats', MRStats);

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ import './core/entities/MRLight';
 import './core/entities/MRModel';
 import './core/entities/MRPanel';
 import './core/entities/MRSkyBox';
+import './core/entities/MRStats';
 import './core/entities/MRTextArea';
 import './core/entities/MRTextField';
 // CORE - COMPONENT-SYSTEMS
@@ -56,6 +57,7 @@ import './core/componentSystems/MaskingSystem';
 import './core/componentSystems/MaterialStyleSystem';
 import './core/componentSystems/PhysicsSystem';
 import './core/componentSystems/SkyBoxSystem';
+import './core/componentSystems/StatsSystem';
 import './core/componentSystems/TextSystem';
 
 // EXPORTS


### PR DESCRIPTION
This PR adds `MRStats(mr-stats)` to allow the stats panel even in immersive mode.

This PR is still draft, but let me share for some questions (see the inline comments) and also for people who already want to use in local test.

Screenshot:

![dec8cc33c34f24a65f0bc684a98f4e16](https://github.com/Volumetrics-io/mrjs/assets/7637832/c734622a-fdfc-4eff-b378-d074c4cd0221)

--

The PR comment will be written when the PR is ready.

## Linking

Fixes #441

## Problem

*Description of the problem including potential code and/or screenshots as an example*

## Solution

*Quick explanation of change to be done*

### Breaking Change

*If this is a breaking change describe the before and after and why the change was necessary*

## Notes

Out of scope in this PR:
* Enhance the stats panel info (eg: add WebGL stats). That would be in another future PR.

------------

## Required to Merge

- [ ] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [ ] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
