### PR TITLE
Upgrade Three.js to r162

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "prettier": "^3.2.4",
         "prettier-eslint-cli": "^8.0.1",
         "stats.js": "^0.17.0",
-        "three": "^0.161.0",
+        "three": "^0.162.0",
         "troika-three-text": "^0.48.1"
       },
       "devDependencies": {
@@ -16611,9 +16611,9 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/three": {
-      "version": "0.161.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.161.0.tgz",
-      "integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
+      "version": "0.162.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
+      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ=="
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "prettier": "^3.2.4",
     "prettier-eslint-cli": "^8.0.1",
     "stats.js": "^0.17.0",
-    "three": "^0.161.0",
+    "three": "^0.162.0",
     "troika-three-text": "^0.48.1"
   }
 }


### PR DESCRIPTION
## Linking

From: https://github.com/Volumetrics-io/mrjs/pull/508#discussion_r1527301176

## Problem

WIP immersive mode stats panel is not displayed correctly with the current Three.js r161, see https://github.com/Volumetrics-io/mrjs/pull/508#discussion_r1527301176

## Solution

Upgrade the Three.js to the latest revision r162

## Notes

We need to test enough to ensure that nothing is broken

------------

## Required to Merge

- [ ] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [ ] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
