### PR TITLE
Drop MRTextEntity traverse method override

### DIFF
--- a/src/core/MRTextEntity.js
+++ b/src/core/MRTextEntity.js
@@ -49,23 +49,6 @@ export class MRTextEntity extends MRDivEntity {
         this.triggerTextStyleUpdate();
     }
 
-    /**
-     * @function
-     * @description Runs the passed through function on this object and every child of this object.
-     * @param {Function} callBack - the function to run recursively.
-     */
-    traverse(callBack) {
-        callBack(this);
-        const children = Array.from(this.object3D.children);
-        for (const child of children) {
-            // if o is an object, traverse it again
-            if ((!child) instanceof MREntity) {
-                continue;
-            }
-            child.traverse(callBack);
-        }
-    }
-
         /**
      * @function
      * @description Triggers a system run to update text specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 


### PR DESCRIPTION
## Linking

Fixes: https://github.com/Volumetrics-io/mrjs/pull/306/files#r1533265296

## Problem

MRTextEntity overrides .traverse() method to traverse .object3D.children (Three.js Object3D collections). But it's a error prone because parent .traverse() traverses .children (HTMLElement collection). Callback function doesn't expect Object3D argument if MRTextEntity.traverse() is called from parent .traverse().

## Solution

Simply drop MRTextEntity.traverse(). Use textEntity.object3D.traverse() instead if object3Ds traverse is needed.

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
