### PR TITLE
Introduce BoundaryVisibilitySystem

### DIFF
--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -25,6 +25,7 @@ import { SkyBoxSystem } from 'mrjs/core/componentSystems/SkyBoxSystem';
 import { TextSystem } from 'mrjs/core/componentSystems/TextSystem';
 import { AudioSystem } from 'mrjs/core/componentSystems/AudioSystem';
 import { PanelSystem } from 'mrjs/core/componentSystems/PanelSystem';
+import { BoundaryVisibilitySystem } from 'mrjs/core/componentSystems/BoundaryVisibilitySystem';
 import MRUser from 'mrjs/core/user/MRUser';
 
 ('use strict');
@@ -119,6 +120,7 @@ export class MRApp extends MRElement {
         this.textSystem = new TextSystem();
         this.geometryStyleSystem = new GeometryStyleSystem();
         this.materialStyleSystem = new MaterialStyleSystem();
+        this.boundaryVisibilitySystem = new BoundaryVisibilitySystem();
 
         // initialize built in Systems
         document.addEventListener('engine-started', (event) => {

--- a/src/core/componentSystems/BoundaryVisibilitySystem.js
+++ b/src/core/componentSystems/BoundaryVisibilitySystem.js
@@ -1,0 +1,81 @@
+import { MRSystem } from 'mrjs/core/MRSystem';
+import { MRDivEntity } from 'mrjs/core/MRDivEntity';
+import { MRPanel } from 'mrjs/core/entities/MRPanel';
+
+/**
+ * @function
+ * @description Observe a target MRDivEntity and make the associated object visible only if it is in visible position in a root MRDivEntity
+ * @param {MRDivEntity} root
+ * @param {MRDivEntity} target
+ */
+const observe = (root, target) => {
+    // TODO: Callback is fired asynchronously so no guaranteed to be called immediately when the
+    //       visibility from the layout position changes. Therefore, the visibility of the associated
+    //       Object3D's might be updated a few frames later after when it really need to be. It might
+    //       affect the user experience. Fix it if possible.
+    const observer = new IntersectionObserver(
+        (entries) => {
+            for (const entry of entries) {
+                // TODO: Endure the visibility set by other systems is not overridden. For example,
+                //       even if another system has made an entity visible within the panel for some reasons,
+                //       this system makes it visible. This issue should be fixed.
+                entry.target.object3D.visible = entry.intersectionRatio > 0;
+            }
+        },
+        {
+            root: root,
+            threshold: 0.0,
+        }
+    );
+    observer.observe(target);
+};
+
+/**
+ * @class BoundaryVisibilitySystem
+ * @classdesc Makes the entities invisible if they are outside of their parent panels
+ * @augments MRSystem
+ */
+export class BoundaryVisibilitySystem extends MRSystem {
+    /**
+     * @class
+     * @description BoundaryVisibilitySystem's default constructor.
+     */
+    constructor() {
+        super(false);
+        this.observedEntities = new WeakSet();
+    }
+
+    /**
+     * @function
+     * @description Called when a new entity is added to the scene.
+     * @param {MREntity} entity - the entity being added.
+     */
+    onNewEntity(entity) {
+        // TODO: Support nested panels
+        if (entity instanceof MRPanel) {
+            this.registry.add(entity);
+            entity.traverse((child) => {
+                if (child === entity) {
+                    return;
+                }
+
+                if (this.observedEntities.has(child)) {
+                    return;
+                }
+
+                this.observedEntities.add(child);
+                observe(entity, child);
+            });
+        } else if (!this.observedEntities.has(entity) && entity instanceof MRDivEntity) {
+            // There is a chance that a child entity is added after parent panel addition.
+            // Check registered panels and set up the observer if panels are found in parents.
+            for (const panel of this.registry) {
+                if (panel.contains(entity)) {
+                    this.observedEntities.add(entity);
+                    observe(panel, entity);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ import './core/entities/MRTextField';
 // CORE - COMPONENT-SYSTEMS
 import './core/componentSystems/AnchorSystem';
 import './core/componentSystems/AnimationSystem';
+import './core/componentSystems/BoundaryVisibilitySystem';
 import './core/componentSystems/ClippingSystem';
 import './core/componentSystems/ControlSystem';
 import './core/componentSystems/GeometryStyleSystem';


### PR DESCRIPTION
## Linking

Fixes #468
Requires #515

## Problem

Currently entities outside of their parent panels are masked with stencil or clipped with clipping. But stencil and clipping are costly.

## Change for solution

Introduce a new system named `BoundaryVisibilitySystem` that makes the entities that outside of their parent panels invisible with `.object3D.visible = false`. It should be much cheaper than stencil or clipping.

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
