### PR TITLE
make the links relative on the testing page for easier swapping between them

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -42,28 +42,28 @@
             Examples
           </mr-text>
         <mr-div class="links col-2">
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/anchors.html">
+          <mr-a class="example-link" href="/examples/anchors.html">
             Anchoring
           </mr-a>
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/audio.html">
+          <mr-a class="example-link" href="/examples/audio.html">
             Audio
           </mr-a>
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/embed.html">
+          <mr-a class="example-link" href="/examples/embed.html">
             Embed
           </mr-a>
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/images.html">
+          <mr-a class="example-link" href="/examples/images.html">
             Images
           </mr-a>
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/models.html">
+          <mr-a class="example-link" href="/examples/models.html">
             Models
           </mr-a>
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/panels.html">
+          <mr-a class="example-link" href="/examples/panels.html">
             Panels
           </mr-a>
-          <mr-a class="example-link" href="https://examples.mrjs.io/examples/skybox.html">
+          <mr-a class="example-link" href="/examples/skybox.html">
             Skybox
           </mr-a>
-           <mr-a class="example-link" href="https://examples.mrjs.io/examples/video.html">
+           <mr-a class="example-link" href="/examples/video.html">
             Video
           </mr-a>
         </mr-div>


### PR DESCRIPTION
## Problem

Links on testing main page arent relative so they go to the full 'examples.mrjs.io' link even when localhosting

## Solution

make them relative

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
~~- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.~~
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
~~- [ ] **BREAKING CHANGE**~~
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
