### PR TITLE
update publish action for a build commit step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,11 +15,6 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
       - uses: actions/setup-node@v4
         with:
           node-version: 21

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           node-version: '20'
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 21
+
       - name: Get version from package.json
         id: package_version
         run: echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
@@ -33,15 +37,36 @@ jobs:
             echo "EXISTS=false" >> $GITHUB_ENV
           fi
 
+      - name: Install Dependencies
+        if: env.EXISTS == 'false'
+        run: |
+          npm install
+
+      - name: 👷 Build again just in case
+        if: env.EXISTS == 'false'
+        run: |
+          rm -rf ./dist
+          npm run build
+
+      - name: Commit the clean build for the tag
+        if: env.EXISTS == 'false'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          commit_message=$'👷 MRjs Publish - Auto Dist For ${{ env.VERSION }} 👷\n\nChanges at '"${GITHUB_SHA}"
+          git add .
+          git commit -m "$commit_message"
+
       - name: Create Git tag
         if: env.EXISTS == 'false'
         run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag v${{ env.VERSION }}
           git push origin v${{ env.VERSION }}
 
       - name: Debug token availability
+        if: env.EXISTS == 'false'
         run: |
           echo "Token length: ${#NPM_MJRS_PUBLISH}"
 


### PR DESCRIPTION
## Linking

Related to [noted console versioning difference](https://discord.com/channels/758943204715659264/1201281972815798343/1219758841915244596) and [followup](https://discord.com/channels/758943204715659264/1201281972815798343/1220453234825756763) 

## Problem

Not guaranteed a clean build in our auto publish cycle

## Solution

Short term solution is adding a clean build in the action itself

## Notes

Our actions are small for now so this is okay, but as we get more extensive in our publishing/documentation/etc cycle (ie after 1.0.0) a clean redo of the actions for better maintainability will be helpful

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
~~- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected~~
~~- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.~~
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
~~- [ ] **BREAKING CHANGE**~~
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
