### PR TITLE
Fix MREntity.traverse()

### DIFF
--- a/src/core/MREntity.js
+++ b/src/core/MREntity.js
@@ -413,11 +413,10 @@ export class MREntity extends MRElement {
         callBack(this);
         const children = Array.from(this.children);
         for (const child of children) {
-            // if o is an object, traverse it again
-            if ((!child) instanceof MREntity) {
-                continue;
+            // if child is an entity, traverse it again
+            if (child instanceof MREntity) {
+                child.traverse(callBack);
             }
-            child.traverse(callBack);
         }
     }
 


### PR DESCRIPTION
## Linking

Fixes: https://github.com/Volumetrics-io/mrjs/pull/125/files#r1535082262

## Problem

MREntity.traverse() wants to go down to a child only if the child is MREntity. But due to a wrong check, it always goes down.

## Change for solution

Fix the bug. Currently `((!child) instanceof MREntity)` is used to decide not to go down but it would be always false because `!child` would be boolean (true/false). `!(child instanceof MREntity)` would be what it really needs to be.

Also, this commit includes a minor clean up.

------------

## Required to Merge

- [ ] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [ ] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
