### PR TITLE
Optimize getBoundingClientRect()

### DIFF
--- a/src/core/MRElement.js
+++ b/src/core/MRElement.js
@@ -12,6 +12,45 @@ export class MRElement extends HTMLElement {
         super();
         this.environment = null;
         this.observer = null;
+
+        // Hack for the performance.
+        // Element.getBoundingClientRect() is called from many places
+        // mainly to sync the layout between DOM elements and 3D scene.
+        // But .getBoundingClientRect() is slow because it may invoke reflow.
+        // To avoid reflow in sync we use a hack with IntersectionObserver
+        // that gives .boundingClientRect in callback function.
+        //
+        // There are some concerns in this approach.
+        // 1. It might be costly to apply this technique to all MREntities.
+        //    Optimization might be necessary to apply it only to MREntities where
+        //    .getBoundingClientRect() is frequently executed.
+        // 2. Since boundingClientRect is updated asynchronously, the latest values
+        //    may be set a few frames late. It is necessary to confirm whether this
+        //    is acceptable for the user experience and various systems. One possible
+        //    workaround, which is not perfect but simple, would be to add a new method
+        //    that is more efficient but may not return the latest value, in addition to
+        //    the regular .getBoundingClientRect() method. The caller can then choose
+        //    which method to use depending on the purpose.
+        // 3. Asynchronous updates can make testing, problem investigation, and debugging
+        //    more difficult. For example, if a bug occurs only when updates are delayed by
+        //    greater than a certain number of frames, it may be difficult to reproduce the
+        //    issue and making problem investigation very challenging. (If IntersectionObserver
+        //    specification guarantees that the callback would always be called during the next
+        //    idle time after .observe() is executed, the problem would be less significant.)
+        this._boundingClientRect = null;
+        const intersectionObserver = new IntersectionObserver((entries) => {
+            for (const entry of entries) {
+                this._boundingClientRect = entry.boundingClientRect;
+            }
+            // Refresh the rect info to keep it up-to-date as much as possible.
+            // It seems that the callback is always called once soon after observe() is called,
+            // regardless of the intersection state of the entity.
+            // TODO: Confirm whether this behavior is intended. If it is not, there may be future
+            //       behavior changes or it may not work as intended on certain platforms.
+            intersectionObserver.disconnect();
+            intersectionObserver.observe(this);
+        });
+        intersectionObserver.observe(this);
     }
 
     /**
@@ -27,4 +66,19 @@ export class MRElement extends HTMLElement {
      * @param {object} entity - the entity to be removed.
      */
     remove(entity) {}
+
+    /**
+     * @function
+     * @description Overrides getBoundingClientRect() to avoid reflow in sync as optimization
+     */
+    getBoundingClientRect() {
+        // This is a fallback in case if .getBoundingClientRect() is called before
+        // ._boundingClientRect is initialized.
+        if (this._boundingClientRect === null) {
+            this._boundingClientRect = super.getBoundingClientRect();
+        }
+        // Assuming the values in the return value object are not overridden in the callers.
+        // If it happens, it affects to all the callers until ._boundingClientRect is refreshed.
+        return this._boundingClientRect;
+    }
 }


### PR DESCRIPTION
## Linking

Fixes #493 

## Problem

Element.getBoundingClientRect() is called from many places mainly to sync the layout between DOM elements and 3D scene. But .getCoundingClientRect() seems to be slow because it may invoke reflow.

## Change for solution

Add a hack with IntersectionObserver to avoid reflow in sync. Please refer to the inline code comments for the details.

## Notes

To reviewers: Please carefully read the inline comments about some concerns and decide whether to merge.

------------

## Required to Merge

- [ ] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [ ] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
  - note: the docs underneath the `Javascript API` section come automated from the jsdocs inline with the code itself
  - link the pr of the documentation repo here: *#pr*
  - that documentation repo pr must be approved by `@lobau`
