### PR TITLE
Fix for scaling bug.

### DIFF
--- a/src/core/componentSystems/GeometryStyleSystem.js
+++ b/src/core/componentSystems/GeometryStyleSystem.js
@@ -28,6 +28,7 @@ export class GeometryStyleSystem extends MRSystem {
     }
 
     /**
+     * @param entity
      * @function
      * @description The per entity triggered update call. Handles updating all 3D items to match whatever geometry/style is expected whether that be a 2D setup or a 3D change.
      */
@@ -39,7 +40,9 @@ export class GeometryStyleSystem extends MRSystem {
         if (entity instanceof MRDivEntity) {
             changed = this.setUpdatedBorder(entity);
         }
+
         changed = this.setScale(entity);
+        
         if (entity instanceof MRMediaEntity) {
             changed = this.setUpdatedMediaPlane(entity);
         }
@@ -86,8 +89,16 @@ export class GeometryStyleSystem extends MRSystem {
         this.registry.add(entity);
     }
 
+    /**
+     *
+     * @param entity
+     */
     setScale(entity) {
-        let new_scale = entity.compStyle.scale != 'none' ? parseFloat(entity.compStyle.scale) * mrjsUtils.app.scale : 1;
+        let new_scale = entity.compStyle.scale != 'none' ? parseFloat(entity.compStyle.scale) : 1;
+
+        if(entity.closest('mr-panel')) {
+            new_scale *= mrjsUtils.app.scale
+        }
         if (new_scale != entity.object3D.scale) {
             entity.object3D.scale.setScalar(new_scale);
             return true;
@@ -96,6 +107,7 @@ export class GeometryStyleSystem extends MRSystem {
     }
 
     /**
+     * @param entity
      * @function
      * @description Sets the border of the UI based on compStyle and inputted css elements.
      */
@@ -121,6 +133,10 @@ export class GeometryStyleSystem extends MRSystem {
         return true;
     }
 
+    /**
+     *
+     * @param entity
+     */
     setUpdatedMediaPlane(entity) {
         entity.computeObjectFitDimensions();
 


### PR DESCRIPTION
## Linking

Options:

- [fix for this issue
](https://github.com/Volumetrics-io/mrjs/issues/538)

## Problem

We're applying UI scaling to all entities, it should only be applied when they're part of a UI panel.

## Solution

check if the Entity is in a UI panel.

### Breaking Change

None

## Notes

https://solgarden.onrender.com/

------------

## Required to Merge

- [ ] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [ ] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: *#pr*
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
