### PR TITLE
`mr-model`: shadows & renderOrder fixed for complex models

### DIFF
--- a/src/core/entities/MRModelEntity.js
+++ b/src/core/entities/MRModelEntity.js
@@ -92,6 +92,14 @@ export class MRModelEntity extends MRDivEntity {
 
             this.loaded = true;
 
+            this.object3D.traverse(object => {
+                if (object.isMesh) {
+                    object.renderOrder = 3;
+                    object.receiveShadow = true;
+                    object.castShadow = true;
+                }
+            })
+
             this.onLoad();
 
             this.dispatchEvent(new CustomEvent('new-entity', { bubbles: true }));

--- a/src/core/entities/MRModelEntity.js
+++ b/src/core/entities/MRModelEntity.js
@@ -92,7 +92,7 @@ export class MRModelEntity extends MRDivEntity {
 
             this.loaded = true;
 
-            this.object3D.traverse(object => {
+            this.traverseObjects(object => {
                 if (object.isMesh) {
                     object.renderOrder = 3;
                     object.receiveShadow = true;


### PR DESCRIPTION
## Linking


## Problem

Shadows and renderOrder were not being applied to all meshes in a loaded model, resulting in a lack of shadows and broken hand masking. 

## Solution

traversing the object hierarchy of the model after it has been loaded, and applying the render order and shadow parameters resolves the issue.

## Notes

tested on both mrjs.io and sol garden. See video

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [x] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [x] **BREAKING CHANGE**
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: *#pr*
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
