### PR TITLE
allow orbital=true to mean no += keypress requirement

### DIFF
--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -246,6 +246,8 @@ export class MRApp extends MRElement {
             orbitControls.minDistance = 1;
             orbitControls.maxDistance = 2;
 
+            // Note: order of the two below if-statements matter.
+            // Want if debug=true and orbital=true for orbital to take priority.
             if (this.orbital) {
                 // always allow orbital controls
                 orbitControls.enabled = true;

--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -245,19 +245,26 @@ export class MRApp extends MRElement {
             const orbitControls = new OrbitControls(this.camera, this.renderer.domElement);
             orbitControls.minDistance = 1;
             orbitControls.maxDistance = 2;
-            orbitControls.enabled = false;
 
-            document.addEventListener('keydown', (event) => {
-                if (event.key == '=') {
-                    orbitControls.enabled = true;
-                }
-            });
+            if (this.orbital) {
+                // always allow orbital controls
+                orbitControls.enabled = true;
+            } else if (this.debug) {
+                // only allow orbital controls on += keypress
+                orbitControls.enabled = false;
+                document.addEventListener('keydown', (event) => {
+                    if (event.key == '=') {
+                        orbitControls.enabled = true;
+                    }
+                });
+                document.addEventListener('keyup', (event) => {
+                    if (event.key == '=') {
+                        orbitControls.enabled = false;
+                    }
+                });
+            }
 
-            document.addEventListener('keyup', (event) => {
-                if (event.key == '=') {
-                    orbitControls.enabled = false;
-                }
-            });
+            
         }
 
         this.appendChild(this.renderer.domElement);


### PR DESCRIPTION
## Linking

related to https://github.com/Volumetrics-io/mrjs/pull/542

## Problem

feature request from laurent

## Solution

just adds an additional if statement to handle it separately from the debug setup s.t. if both debug=true and orbital=true, the orbital=true takes priority

### Breaking Change

regardless of debug or not - when focus is on orbital=true, allow orbital by default without keypress

## Notes

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [x] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [x] **BREAKING CHANGE**
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: https://github.com/Volumetrics-io/documentation/pull/40
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
