### PR TITLE
make check-format pass again s.t. we can use the 'all green again' check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "docs": "./scripts/create-docs.sh",
     "prettier-check": "prettier --check \"src/**/*.js\" \"*.js\"",
     "prettier-fix": "prettier --write \"src/**/*.js\" \"*.js\"",
-    "lint-check": "eslint \"src/**/*.js\" \"*.js\" --max-warnings 0",
-    "lint-fix": "eslint \"src/**/*.js\" \"*.js\" --fix",
+    "lint-check": "eslint \"src/**/*.js\" \"*.js\" --ignore-pattern \"src/extras/**\" --max-warnings 0",
+    "lint-fix": "eslint \"src/**/*.js\" \"*.js\" --ignore-pattern \"src/extras/**\" --fix",
     "format": "npm run prettier-fix && npm run lint-fix",
     "check-format": "npm run prettier-list && npm run lint-list"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint-check": "eslint \"src/**/*.js\" \"*.js\" --ignore-pattern \"src/extras/**\" --max-warnings 0",
     "lint-fix": "eslint \"src/**/*.js\" \"*.js\" --ignore-pattern \"src/extras/**\" --fix",
     "format": "npm run prettier-fix && npm run lint-fix",
-    "check-format": "npm run prettier-list && npm run lint-list"
+    "check-format": "npm run prettier-check && npm run lint-check"
   },
   "repository": {
     "type": "git",

--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -39,7 +39,6 @@ window.mobileCheck = function () {
  * @augments MRElement
  */
 export class MRApp extends MRElement {
-
     /**
      * @class
      * @description Constructs the base information of the app including system, camera, engine, xr, and rendering defaults.
@@ -65,7 +64,7 @@ export class MRApp extends MRElement {
 
         // The rest of the renderer is filled out in this.connectedCallback()-->this.init() since
         // the renderer relies on certain component flags attached to the <mr-app> itself.
-        this.renderer = null; 
+        this.renderer = null;
 
         this.lighting = {
             enabled: true,
@@ -206,7 +205,7 @@ export class MRApp extends MRElement {
 
         this.renderer = new THREE.WebGLRenderer({
             antialias: true,
-            alpha: true, 
+            alpha: true,
             // There's issues in the timing to enable taking screenshots of threejs scenes unless you have direct access to the code.
             // Using the preserveDrawingBuffer to ignore timing issues is the best approach instead. Though this has a performance hit,
             // we're allowing it to be enabled by users when necessary.
@@ -270,8 +269,6 @@ export class MRApp extends MRElement {
                     }
                 });
             }
-
-            
         }
 
         this.appendChild(this.renderer.domElement);

--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -39,27 +39,6 @@ window.mobileCheck = function () {
  * @augments MRElement
  */
 export class MRApp extends MRElement {
-    /**
-     *
-     */
-    get appWidth() {
-        let result = parseFloat(this.compStyle.width.split('px')[0]);
-        if (mrjsUtils.xr.isPresenting) {
-            result = (result / window.innerWidth) * mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
-        }
-        return result;
-    }
-
-    /**
-     *
-     */
-    get appHeight() {
-        let result = parseFloat(this.compStyle.height.split('px')[0]);
-        if (mrjsUtils.xr.isPresenting) {
-            result = (result / window.screen.height) * mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
-        }
-        return result;
-    }
 
     /**
      * @class
@@ -101,6 +80,32 @@ export class MRApp extends MRElement {
         };
         this.render = this.render.bind(this);
         this.onWindowResize = this.onWindowResize.bind(this);
+    }
+
+    /**
+     * @function
+     * @memberof MRApp
+     * @returns {number} width in 3d or pixel space (depending on if in xr) of the current open app
+     */
+    get appWidth() {
+        let result = parseFloat(this.compStyle.width.split('px')[0]);
+        if (mrjsUtils.xr.isPresenting) {
+            result = (result / window.innerWidth) * mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
+        }
+        return result;
+    }
+
+    /**
+     * @function
+     * @memberof MRApp
+     * @returns {number} height in 3d or pixel space (depending on if in xr) of the current open app
+     */
+    get appHeight() {
+        let result = parseFloat(this.compStyle.height.split('px')[0]);
+        if (mrjsUtils.xr.isPresenting) {
+            result = (result / window.screen.height) * mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
+        }
+        return result;
     }
 
     /**

--- a/src/core/MRElement.js
+++ b/src/core/MRElement.js
@@ -57,6 +57,7 @@ export class MRElement extends HTMLElement {
     /**
      * @function
      * @description Overrides getBoundingClientRect() to avoid reflow in sync as optimization
+     * @returns {object} rect - the bounding client rect of the HTMLElement representation of this MRElement.
      */
     getBoundingClientRect() {
         // This is a fallback in case if .getBoundingClientRect() is called before

--- a/src/core/MREntity.js
+++ b/src/core/MREntity.js
@@ -102,7 +102,6 @@ export class MREntity extends MRElement {
      * @function
      * @description Triggers a system run to update geometry specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
      * relying on an overall scene or all items to update isnt beneficial.
-     * @returns {number} - height of the 3D object.
      */
     triggerGeometryStyleUpdate() {
         this.dispatchEvent(new CustomEvent('trigger-geometry-style-update', { detail: this, bubbles: true }));
@@ -112,7 +111,6 @@ export class MREntity extends MRElement {
      * @function
      * @description Triggers a system run to update material specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
      * relying on an overall scene or all items to update isnt beneficial.
-     * @returns {number} - height of the 3D object.
      */
     triggerMaterialStyleUpdate() {
         this.dispatchEvent(new CustomEvent('trigger-material-style-update', { detail: this, bubbles: true }));
@@ -120,15 +118,17 @@ export class MREntity extends MRElement {
 
     /**
      * @function
-     * @description Inside the MRjs engine's ECS these arent filled in, though theyre still called directly in the system themselves. This allows outside users to add their own additional functionality for the entities.
-     * These are run after the MaterialStyleSystem does its own update on the entity.
+     * @description Directly in MRjs, this function is empty. It is called directly in the 
+     * MaterialStyleSystem. This allows outside users to add their own additional functionality
+     * for the entities. These are run after the MaterialStyleSystem does its own update on the entity.
      */
     updateMaterialStyle() {}
 
     /**
      * @function
-     * @description Inside the MRjs engine's ECS these arent filled in, though theyre still called directly in the system themselves. This allows outside users to add their own additional functionality for the entities.
-     * These are run after the GeometryStyleSystem does its own update on the entity.
+     * @description Directly in MRjs, this function is empty. It is called directly in the 
+     * GeometryStyleSystem. This allows outside users to add their own additional functionality
+     * for the entities. These are run after the GeometryStyleSystem does its own update on the entity.
      */
     updateGeometryStyle() {}
 

--- a/src/core/MREntity.js
+++ b/src/core/MREntity.js
@@ -30,7 +30,6 @@ export class MREntity extends MRElement {
     constructor() {
         super();
 
-
         this.object3D = new THREE.Group();
         this.object3D.userData.isEntityObject3DRoot = true;
         this.object3D.userData.bbox = new THREE.Box3();
@@ -100,7 +99,7 @@ export class MREntity extends MRElement {
 
     /**
      * @function
-     * @description Triggers a system run to update geometry specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
+     * @description Triggers a system run to update geometry specifically for the entity calling it. Useful when it's not an overall scene event and for cases where
      * relying on an overall scene or all items to update isnt beneficial.
      */
     triggerGeometryStyleUpdate() {
@@ -109,7 +108,7 @@ export class MREntity extends MRElement {
 
     /**
      * @function
-     * @description Triggers a system run to update material specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
+     * @description Triggers a system run to update material specifically for the entity calling it. Useful when it's not an overall scene event and for cases where
      * relying on an overall scene or all items to update isnt beneficial.
      */
     triggerMaterialStyleUpdate() {
@@ -118,7 +117,7 @@ export class MREntity extends MRElement {
 
     /**
      * @function
-     * @description Directly in MRjs, this function is empty. It is called directly in the 
+     * @description Directly in MRjs, this function is empty. It is called directly in the
      * MaterialStyleSystem. This allows outside users to add their own additional functionality
      * for the entities. These are run after the MaterialStyleSystem does its own update on the entity.
      */
@@ -126,7 +125,7 @@ export class MREntity extends MRElement {
 
     /**
      * @function
-     * @description Directly in MRjs, this function is empty. It is called directly in the 
+     * @description Directly in MRjs, this function is empty. It is called directly in the
      * GeometryStyleSystem. This allows outside users to add their own additional functionality
      * for the entities. These are run after the GeometryStyleSystem does its own update on the entity.
      */
@@ -149,7 +148,7 @@ export class MREntity extends MRElement {
      * @param {object} event - the touch event
      */
     onTouch = (event) => {};
- 
+
     /**
      * @function
      * @description Handles the scroll event
@@ -188,7 +187,7 @@ export class MREntity extends MRElement {
             if (arr.length != 3) {
                 mrjsUtils.error.err('position must be set with an array of all three elements [x, y, z]');
             }
-            let vec = mrjsUtils.string.stringToVector(this.dataset.position ?? "0 0 0");
+            let vec = mrjsUtils.string.stringToVector(this.dataset.position ?? '0 0 0');
             vec[0] = arr[0];
             vec[1] = arr[1];
             vec[2] = arr[2];
@@ -224,7 +223,7 @@ export class MREntity extends MRElement {
             vec[2] = val;
             this.dataset.position = mrjsUtils.string.vectorToString(vec);
         },
-    }
+    };
 
     rotation = {
         get: () => {
@@ -235,7 +234,7 @@ export class MREntity extends MRElement {
             if (arr.length != 3) {
                 mrjsUtils.error.err('rotation must be set with an array of all three elements [x, y, z]');
             }
-            let vec = mrjsUtils.string.stringToVector(this.dataset.rotation ?? "0 0 0")
+            let vec = mrjsUtils.string.stringToVector(this.dataset.rotation ?? '0 0 0');
             vec[0] = arr[0];
             vec[1] = arr[1];
             vec[2] = arr[2];
@@ -271,7 +270,7 @@ export class MREntity extends MRElement {
             vec[2] = val;
             this.dataset.rotation = mrjsUtils.string.vectorToString(vec);
         },
-    }
+    };
 
     /**
      * @function
@@ -310,10 +309,10 @@ export class MREntity extends MRElement {
      */
     connected() {}
 
-        /**
-         * @function
-         * @description The connectedCallback function that runs whenever this entity component becomes connected to something else.
-         */
+    /**
+     * @function
+     * @description The connectedCallback function that runs whenever this entity component becomes connected to something else.
+     */
     connectedCallback() {
         this.compStyle = window.getComputedStyle(this);
 

--- a/src/core/MRSystem.js
+++ b/src/core/MRSystem.js
@@ -68,14 +68,14 @@ export class MRSystem {
     /**
      * @function
      * @description Called when a new entity is added to the scene
-     * @param {MRApp} app - the app the system is registered to.
+     * @param {object} app - the app the system is registered to.
      */
     onRegister(app) {}
 
     /**
      * @function
      * @description Called when the system is registered to an app is added.
-     * @param {MRApp} app - the app the system is registered to.
+     * @param {object} app - the app the system is registered to.
      */
     onUnregister(app) {}
 

--- a/src/core/MRSystem.js
+++ b/src/core/MRSystem.js
@@ -107,7 +107,7 @@ export class MRSystem {
     /**
      * @function
      * @description An event triggered update, called when any global scene level events occur.
-     * See GLOBAL_UPDATE_EVENTS of MRSystem.js 
+     * See GLOBAL_UPDATE_EVENTS of MRSystem.js
      */
     eventUpdate() {}
 

--- a/src/core/componentSystems/AnchorSystem.js
+++ b/src/core/componentSystems/AnchorSystem.js
@@ -155,8 +155,9 @@ export class AnchorSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Called when the entity component is initialized
+     * @param {object} entity - the entity being attached/initialized.
      */
     attachedComponent(entity) {
         entity.object3D.userData.originalMatrix = new THREE.Matrix4();
@@ -165,8 +166,9 @@ export class AnchorSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Called when the entity component is updated
+     * @param {object} entity - the entity being updated based on the component.
      */
     updatedComponent(entity) {
         // delete before creating a new one.
@@ -176,8 +178,9 @@ export class AnchorSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Called when the entity component is detached
+     * @param {object} entity - the entity being updated based on the component being detached.
      */
     detachedComponent(entity) {
         entity.object3D.matrixAutoUpdate = true;
@@ -187,7 +190,7 @@ export class AnchorSystem extends MRSystem {
     /**
      * @function
      * @description deletes anchors from the scene and removes all references to the anchored plane (if any)
-     * @param entity
+     * @param {object} entity - the entity whose anchor is being deleted.
      */
     deleteAnchor(entity) {
         if (entity.plane) {
@@ -202,8 +205,8 @@ export class AnchorSystem extends MRSystem {
     /**
      * @function
      * @description creates the anchor specified by the data-anchor-comp
-     * @param entity
-     * @param comp
+     * @param {object} entity - the entity whose anchor is being created.
+     * @param {object} comp - the data component with a type value that represents the string 'fixed', 'plane', 'floating', etc
      */
     createAnchor(entity, comp) {
         switch (comp.type) {
@@ -222,6 +225,11 @@ export class AnchorSystem extends MRSystem {
         }
     }
 
+    /**
+     * @function
+     * @description Sets the origin of the MRApp being touched by all systems to allow anchoring to position
+     * itself properly.
+     */
     setAppOrigin() {
         if (!mrjsUtils.xr.isPresenting) {
             return;
@@ -242,6 +250,11 @@ export class AnchorSystem extends MRSystem {
         });
     }
 
+    /**
+     * @function
+     * @description Updates the origin of the MRApp being touched by all systems to allow anchoring to position.
+     * @param {object} frame - given frame information to be used for any feature changes (from the update(..) loop)
+     */
     updateOrigin(frame) {
         let pose = frame.getPose(this.app.anchor.anchorSpace, mrjsUtils.xr.referenceSpace);
         let transform = this.multiplyQuaternionWithXRRigidTransform(this.axisSwapQuat, pose.transform);
@@ -253,8 +266,8 @@ export class AnchorSystem extends MRSystem {
 
     /**
      * @function
-     * @description anchors the given entity half a meter in front of the users position at launch.
-     * @param entity
+     * @description Anchors the given entity half a meter in front of the users position at launch.
+     * @param {object} entity - the entity being positioned.
      */
     fixed(entity) {
         this.anchoringQueue.add(entity);
@@ -274,9 +287,9 @@ export class AnchorSystem extends MRSystem {
 
     /**
      * @function
-     * @description creates an anchor at the position specified by the user,
+     * @description Creates an anchor at the position specified by the user,
      * either floating in front of them or pinned to the scene mesh
-     * @param frame
+     * @param {object} frame - given frame information to be used for any feature changes (from the update(..) loop)
      */
     floating(frame) {
         this.hitResults = frame.getHitTestResults(this.source);
@@ -293,10 +306,10 @@ export class AnchorSystem extends MRSystem {
 
     /**
      * @function
-     * @description anchors the provided entity to the nearest unoccupied plane that meets the given orientation and label.
+     * @description Anchors the provided entity to the nearest unoccupied plane that meets the given orientation and label.
      * each plane is currently limited to one anchor for simplicity.
-     * @param entity
-     * @param comp
+     * @param {object} entity - the entity being anchored by this function.
+     * @param {object} comp - the data-component to determine the orientation and label of the associated plane
      */
     plane(entity, comp) {
         this.anchoringQueue.add(entity);
@@ -352,8 +365,9 @@ export class AnchorSystem extends MRSystem {
      * @function
      * @description converts the provided XRRigidTransform to a Matrix4 and adjusts it to ensure
      * that it's y-axis is pointing directly up and it's z-axis is facing inward
-     * @param xrRigidTransform
-     * @returns a THREE.js Matrix4
+     * @param {object} xrRigidTransform - a THREE.js transformation matrix that we want to adjust
+     * @param {boolean} origin - true if this is positioned at the origin or not (handles special case of div-0).
+     * @returns {object} a new adjusted THREE.js Matrix4
      */
     adjustTransform(xrRigidTransform, origin = false) {
         // Create a Three.js Quaternion for the XRRigidTransform's orientation
@@ -391,8 +405,9 @@ export class AnchorSystem extends MRSystem {
 
     /**
      * @function
-     * @description converts the provided matrix4 into a webXR xompatible XRRigidTransform
-     * @param matrix4
+     * @description Converts the provided matrix4 into a webXR xompatible XRRigidTransform
+     * @param {object} matrix4 - the matrix we want to convert to a XRRigidTransform
+     * @returns {object} xrRigidTransform - the converted representation of the param matrix4
      */
     matrix4ToXRRigidTransform(matrix4) {
         // Extract the translation component from the Matrix4
@@ -415,9 +430,10 @@ export class AnchorSystem extends MRSystem {
 
     /**
      * @function
-     * @description multuplies an xr rigid transform by the provided quaternion
-     * @param quaternion
-     * @param xrRigidTransform
+     * @description Multiplies an xr rigid transform by the provided quaternion
+     * @param {object} quaternion - the quaternion we want to multiply with the xrRigidTransform
+     * @param {object} xrRigidTransform - the second part of the multiplication we are looking to perform.
+     * @returns {object} xrRigidTransform - the output of the quaternion * xrRigidTransform in the form of an xrRigidTransform
      */
     multiplyQuaternionWithXRRigidTransform(quaternion, xrRigidTransform) {
         // Create a Three.js Quaternion for the XRRigidTransform's orientation

--- a/src/core/componentSystems/AnimationSystem.js
+++ b/src/core/componentSystems/AnimationSystem.js
@@ -37,6 +37,11 @@ export class AnimationSystem extends MRSystem {
         }
     }
 
+    /**
+     * @function
+     * @description Called when the entity component is initialized
+     * @param {object} entity - the entity being attached/initialized.
+     */
     attachedComponent(entity) {
         let comp = entity.components.get('animation');
         if (entity instanceof MRModelEntity && entity.animations.length > 0) {
@@ -46,6 +51,11 @@ export class AnimationSystem extends MRSystem {
         }
     }
 
+    /**
+     * @function
+     * @description Called when the entity component is updated
+     * @param {object} entity - the entity being updated based on the component.
+     */
     updatedComponent(entity) {
         let comp = entity.components.get('animation');
         if (entity instanceof MRModelEntity && entity.animations.length > 0) {
@@ -53,10 +63,20 @@ export class AnimationSystem extends MRSystem {
         }
     }
 
+    /**
+     * @function
+     * @description Called when the entity component is detached
+     * @param {object} entity - the entity being updated based on the component being detached.
+     */
     detachedComponent(entity) {
         entity.mixer.stopAllActions();
     }
 
+    /**
+     * @function
+     * @description When the system swaps to a new entity, this handles setting up the animations for the system runs.
+     * @param {object} entity - given entity that might be handled by the system.
+     */
     onNewEntity(entity) {
         if (entity instanceof MRModelEntity && entity.animations.length > 0) {
             let comp = entity.components.get('animation');
@@ -69,6 +89,12 @@ export class AnimationSystem extends MRSystem {
         }
     }
 
+    /**
+     * @function
+     * @description Sets the Animation of the entity object based on the component value associated with it.
+     * @param {object} entity - the entity being updated based on the component being detached.
+     * @param {object} comp - component that contains a string value of 'play', 'pause', 'stop'
+     */
     setAnimation(entity, comp) {
         let clip = entity.animations[comp.clip];
         switch (comp.action) {

--- a/src/core/componentSystems/AudioSystem.js
+++ b/src/core/componentSystems/AudioSystem.js
@@ -20,18 +20,20 @@ export class AudioSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param dt
-     * @param frame
+     * @function
+     * @description The generic system update call. Updates the clipped view of every entity in this system's registry.
+     * @param {number} deltaTime - given timestep to be used for any feature changes
+     * @param {object} frame - given frame information to be used for any feature changes
      */
-    update(dt, frame) {
+    update(deltaTime, frame) {
         this.listener.position.setFromMatrixPosition(this.app.user.origin.matrixWorld);
         this.listener.setRotationFromMatrix(this.app.user.origin.matrixWorld);
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Called when the entity component is initialized
+     * @param {object} entity - the entity being attached/initialized.
      */
     attachedComponent(entity) {
         entity.sound = new THREE.PositionalAudio(this.listener);
@@ -51,8 +53,9 @@ export class AudioSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Called when the entity component is updated
+     * @param {object} entity - the entity being updated based on the component.
      */
     updatedComponent(entity) {
         let comp = entity.components.get('audio');
@@ -62,8 +65,9 @@ export class AudioSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Called when the entity component is detached
+     * @param {object} entity - the entity being updated based on the component being detached.
      */
     detachedComponent(entity) {
         entity.sound.stop();
@@ -72,9 +76,10 @@ export class AudioSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
-     * @param state
+     * @function
+     * @description Updates the Audio State based on the user passed 'state' variable.
+     * @param {object} entity - the entity being updated based on the component being detached.
+     * @param {string} state - represents a parameter for the state of the sound 'play', 'pause', 'stop', etc
      */
     setAudioState(entity, state) {
         switch (state) {

--- a/src/core/componentSystems/BoundaryVisibilitySystem.js
+++ b/src/core/componentSystems/BoundaryVisibilitySystem.js
@@ -33,7 +33,7 @@ const observe = (root, target) => {
             observer.observe(target);
         },
         {
-            root: root
+            root: root,
         }
     );
     observer.observe(target);

--- a/src/core/componentSystems/BoundaryVisibilitySystem.js
+++ b/src/core/componentSystems/BoundaryVisibilitySystem.js
@@ -5,8 +5,8 @@ import { MRPanelEntity } from 'mrjs/core/entities/MRPanelEntity';
 /**
  * @function
  * @description Observe a target MRDivEntity and make the associated object visible only if it is in visible position in a root MRDivEntity
- * @param {MRDivEntity} root
- * @param {MRDivEntity} target
+ * @param {MRDivEntity} root - the root object being compared against
+ * @param {MRDivEntity} target - the target object for which we're determining visiblity.
  */
 const observe = (root, target) => {
     // TODO: Callback is fired asynchronously so no guaranteed to be called immediately when the
@@ -57,7 +57,7 @@ export class BoundaryVisibilitySystem extends MRSystem {
     /**
      * @function
      * @description Called when a new entity is added to the scene.
-     * @param {MREntity} entity - the entity being added.
+     * @param {object} entity - the entity being added.
      */
     onNewEntity(entity) {
         // TODO: Support nested panels

--- a/src/core/componentSystems/ControlSystem.js
+++ b/src/core/componentSystems/ControlSystem.js
@@ -103,6 +103,11 @@ export class ControlSystem extends MRSystem {
         }
     }
 
+    /**
+     * @function
+     * @description Check for any collisions with this MRHand and the rapier physics world.
+     * @param {object} hand - the MRHand object whose collisions we are checking with this function.
+     */
     checkCollisions(hand) {
         for (let jointCursor of hand.jointCursors) {
             mrjsUtils.physics.world.contactPairsWith(jointCursor.collider, (collider2) => {
@@ -182,7 +187,7 @@ export class ControlSystem extends MRSystem {
      * @description Handles the start of touch between two different colliders and the current entity.
      * @param {number} collider1 - the first collider
      * @param {number} collider2 - the second collider
-     * @param {MREntity} entity - the current entity
+     * @param {object} entity - the current entity
      */
     touchStart = (collider1, collider2, entity) => {
         entity.touch = true;
@@ -207,7 +212,7 @@ export class ControlSystem extends MRSystem {
     /**
      * @function
      * @description Handles the end of touch for the current entity
-     * @param {MREntity} entity - the current entity
+     * @param {object} entity - the current entity
      */
     touchEnd = (entity) => {
         this.tempPreviousPosition.set(0, 0, 0);
@@ -228,7 +233,7 @@ export class ControlSystem extends MRSystem {
      * @description Handles the start of hovering over/around a specific entity.
      * @param {number} collider1 - the first collider
      * @param {number} collider2 - the second collider
-     * @param {MREntity} entity - the current entity
+     * @param {object} entity - the current entity
      */
     hoverStart = (collider1, collider2, entity) => {
         entity.classList.add('hover');
@@ -253,7 +258,7 @@ export class ControlSystem extends MRSystem {
     /**
      * @function
      * @description Handles the end of hovering over/around a specific entity.
-     * @param {MREntity} entity - the current entity
+     * @param {object} entity - the current entity
      */
     hoverEnd = (entity) => {
         entity.classList.remove('hover');
@@ -266,6 +271,10 @@ export class ControlSystem extends MRSystem {
         entity.dispatchEvent(new MouseEvent('mouseleave'));
     };
 
+    /**
+     * @function
+     * @description Fills in the this.origin,direction,ray, and hit values based on the rapier world
+     */
     pointerRay() {
         this.origin.setFromMatrixPosition(this.app.user.origin.matrixWorld);
         this.direction.setFromMatrixPosition(this.activeHand.pointer.matrixWorld).sub(this.origin).normalize();
@@ -343,6 +352,12 @@ export class ControlSystem extends MRSystem {
         this.currentEntity = null;
     };
 
+    /**
+     * @function
+     * @description Checks what kind of interactions should happen based on the current entity and any events that
+     * have happened so far.
+     * @param {object} entity - checking if there is any interaction required based on current events and this entity.
+     */
     interact(entity) {
         if (!entity) {
             return;
@@ -401,7 +416,7 @@ export class ControlSystem extends MRSystem {
         let y = 0;
         if (event.type.includes('touchmove')) {
             if (event.touches.length == 0) {
-                return;
+                return null;
             }
 
             x = event.touches[0].clientX;

--- a/src/core/componentSystems/GeometryStyleSystem.js
+++ b/src/core/componentSystems/GeometryStyleSystem.js
@@ -28,8 +28,8 @@ export class GeometryStyleSystem extends MRSystem {
     }
 
     /**
-     * @param entity
      * @function
+     * @param {object} entity - the MREntity to be updated by this function.
      * @description The per entity triggered update call. Handles updating all 3D items to match whatever geometry/style is expected whether that be a 2D setup or a 3D change.
      */
     _updateSpecificEntity(entity) {
@@ -90,8 +90,10 @@ export class GeometryStyleSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Sets the scale of the MREntity based on its css scale value, otherwise defaults to 1.
+     * @param {object} entity - the MREntity to be updated by this function.
+     * @returns {boolean} true if updated, false otherwise.
      */
     setScale(entity) {
         let new_scale = entity.compStyle.scale != 'none' ? parseFloat(entity.compStyle.scale) : 1;
@@ -103,9 +105,10 @@ export class GeometryStyleSystem extends MRSystem {
     }
 
     /**
-     * @param entity
      * @function
      * @description Sets the border of the UI based on compStyle and inputted css elements.
+     * @param {object} entity - the MREntity to be updated by this function.
+     * @returns {boolean} true if updated, false otherwise
      */
     setUpdatedBorder(entity) {
         // geometry will only update if width, height, or borderRadii have changed
@@ -130,8 +133,10 @@ export class GeometryStyleSystem extends MRSystem {
     }
 
     /**
-     *
-     * @param entity
+     * @function
+     * @description Updates the Media Plane for this geometry. Specific to the MRMedia subclasses.
+     * @param {object} entity - the MRMediaEntity to be updated by this function.
+     * @returns {boolean} true if updated, false otherwise
      */
     setUpdatedMediaPlane(entity) {
         entity.computeObjectFitDimensions();
@@ -145,8 +150,6 @@ export class GeometryStyleSystem extends MRSystem {
             // no update needed
             return false;
         }
-
-        
 
         return true;
     }

--- a/src/core/componentSystems/GeometryStyleSystem.js
+++ b/src/core/componentSystems/GeometryStyleSystem.js
@@ -42,7 +42,7 @@ export class GeometryStyleSystem extends MRSystem {
         }
 
         changed = this.setScale(entity);
-        
+
         if (entity instanceof MRMediaEntity) {
             changed = this.setUpdatedMediaPlane(entity);
         }
@@ -71,7 +71,7 @@ export class GeometryStyleSystem extends MRSystem {
 
     /**
      * @function
-     * @description The per-frame system update call. 
+     * @description The per-frame system update call.
      * @param {number} deltaTime - given timestep to be used for any feature changes
      * @param {object} frame - given frame information to be used for any feature changes
      */
@@ -142,10 +142,8 @@ export class GeometryStyleSystem extends MRSystem {
         entity.computeObjectFitDimensions();
 
         // geometry will only update if width, height, or borderRadii have changed
-        if (entity._storedWidth != entity.width
-            || entity._storedHeight != entity.height
-            || entity._storedBorderRadii != entity.borderRadii) {
-           entity.generateNewMediaPlaneGeometry();
+        if (entity._storedWidth != entity.width || entity._storedHeight != entity.height || entity._storedBorderRadii != entity.borderRadii) {
+            entity.generateNewMediaPlaneGeometry();
         } else {
             // no update needed
             return false;

--- a/src/core/componentSystems/LayoutSystem.js
+++ b/src/core/componentSystems/LayoutSystem.js
@@ -61,7 +61,7 @@ export class LayoutSystem extends MRSystem {
         }
         const panelRect = panel.getBoundingClientRect();
 
-        /** setup xy positioning of the entity **/
+        /** setup xy positioning of the entity */
 
         let innerWidth = parseFloat(panel.compStyle.width.split('px')[0]);
         let innerHeight = parseFloat(panel.compStyle.height.split('px')[0]);
@@ -82,7 +82,7 @@ export class LayoutSystem extends MRSystem {
         entity.object3D.position.setX(threeX);
         entity.object3D.position.setY(-threeY);
 
-        /** setup z-index positioning of the entity **/
+        /** setup z-index positioning of the entity */
 
         if (entity.compStyle.zIndex != 'auto') {
             // default zIndex values in css are in the 1000s - using this arbitrary divide to convert to an actual usable threejs value.

--- a/src/core/componentSystems/MaskingSystem.js
+++ b/src/core/componentSystems/MaskingSystem.js
@@ -46,9 +46,9 @@ const MAX_PANEL_NUM = 8;
 /**
  * @function
  * @description Setting up a material for an object that maskes other elements
- * @param {THREE.Material} material
- * @param {number} shiftBit
- * @param {debug} boolean
+ * @param {THREE.Material} material - the material whose values are augmented to mask as expected.
+ * @param {number} shiftBit - used to offset the stencilWriteMask and stencilRef.
+ * @param {boolean} debug - true if in debug mode, false otherwise
  */
 const setupMaskingMaterial = (material, shiftBit, debug = false) => {
     material.transparent = true;
@@ -69,8 +69,8 @@ const setupMaskingMaterial = (material, shiftBit, debug = false) => {
 /**
  * @function
  * @description Setting up a material for an object that is masked by another element
- * @param {THREE.Material} material
- * @param {number} shiftBit
+ * @param {THREE.Material} material - the material whose values are augmented to mask as expected.
+ * @param {number} shiftBit - used to offset the stencilWriteMask and stencilRef.
  */
 const setupMaskedMaterial = (material, shiftBit) => {
     material.stencilWrite = true;

--- a/src/core/componentSystems/MaterialStyleSystem.js
+++ b/src/core/componentSystems/MaterialStyleSystem.js
@@ -84,7 +84,10 @@ export class MaterialStyleSystem extends MRSystem {
         const color = entity.compStyle.backgroundColor;
 
         if (color.startsWith('rgba')) {
-            const rgba = color.match(/rgba?\(([^)]+)\)/)[1].split(',').map(n => parseFloat(n.trim()));
+            const rgba = color
+                .match(/rgba?\(([^)]+)\)/)[1]
+                .split(',')
+                .map((n) => parseFloat(n.trim()));
             entity.background.material.color.setStyle(`rgb(${rgba[0]}, ${rgba[1]}, ${rgba[2]})`);
             entity.background.material.transparent = rgba.length === 4 && rgba[3] < 1;
             entity.background.material.opacity = rgba.length === 4 ? rgba[3] : 1;
@@ -95,7 +98,7 @@ export class MaterialStyleSystem extends MRSystem {
             entity.background.material.transparent = false;
             entity.background.visible = true;
         } else if (color.startsWith('#')) {
-            const {r, g, b, a} = mrjsUtils.color.hexToRgba(color);
+            const { r, g, b, a } = mrjsUtils.color.hexToRgba(color);
             entity.background.material.color.setStyle(`rgb(${r}, ${g}, ${b})`);
             entity.background.material.transparent = a < 1;
             entity.background.material.opacity = a;

--- a/src/core/componentSystems/MaterialStyleSystem.js
+++ b/src/core/componentSystems/MaterialStyleSystem.js
@@ -29,6 +29,7 @@ export class MaterialStyleSystem extends MRSystem {
 
     /**
      * @function
+     * @param {object} entity - the MREntity being updated.
      * @description The per entity triggered update call. Handles updating all 3D items to match whatever geometry/style is expected whether that be a 2D setup or a 3D change.
      */
     _updateSpecificEntity(entity) {
@@ -68,7 +69,7 @@ export class MaterialStyleSystem extends MRSystem {
     /**
      * @function
      * @description Called when a new entity is added to the scene. Adds said new entity to the style's system registry.
-     * @param {MREntity} entity - the entity being added.
+     * @param {object} entity - the MREntity being touched by this function.
      */
     onNewEntity(entity) {
         this.registry.add(entity);
@@ -76,6 +77,7 @@ export class MaterialStyleSystem extends MRSystem {
 
     /**
      * @function
+     * @param {object} entity - the MREntity being updated.
      * @description Sets the background based on compStyle and inputted css elements.
      */
     setBackground(entity) {
@@ -111,9 +113,16 @@ export class MaterialStyleSystem extends MRSystem {
         entity.background.material.needsUpdate = true;
     }
 
+    /**
+     * @function
+     * @description Sets the visibility of the MREntity based on its css 'visibility' property.
+     * @param {object} entity - the MREntity being updated.
+     */
     setVisibility(entity) {
-        function makeVisible(entity, bool) {
-            entity.object3D.visible = bool;
+        if (entity.compStyle.visibility && entity.compStyle.visibility !== 'none' && entity.compStyle.visibility !== 'collapse') {
+            // visbility: hidden or visible are the options we care about
+            const isVisible = entity.compStyle.visibility !== 'hidden';
+            entity.object3D.visible = isVisible;
             if (entity.background) {
                 // The background for MRDivEntity, but we want this css property allowed
                 // for all, so using this checker to confirm the existence first.
@@ -124,11 +133,6 @@ export class MaterialStyleSystem extends MRSystem {
                 // if this is requested for use or we want to add a feature for more use of the
                 // background - adding in toggling for this with the object will be useful.
             }
-        }
-        if (entity.compStyle.visibility && entity.compStyle.visibility !== 'none' && entity.compStyle.visibility !== 'collapse') {
-            // visbility: hidden or visible are the options we care about
-            const isVisible = entity.compStyle.visibility !== 'hidden';
-            makeVisible(entity, isVisible);
         }
     }
 }

--- a/src/core/componentSystems/PanelSystem.js
+++ b/src/core/componentSystems/PanelSystem.js
@@ -19,7 +19,7 @@ export class PanelSystem extends MRSystem {
 
     eventUpdate = () => {
         for (const entity of this.registry) {
-            entity.panel.scale.setScalar(mrjsUtils.app.scale)
+            entity.panel.scale.setScalar(mrjsUtils.app.scale);
         }
     };
 

--- a/src/core/componentSystems/PanelSystem.js
+++ b/src/core/componentSystems/PanelSystem.js
@@ -26,12 +26,10 @@ export class PanelSystem extends MRSystem {
     /**
      * @function
      * @description The generic system update call. keeps panel positions up to date.
-     * @param dt
-     * @param f
      * @param {number} deltaTime - given timestep to be used for any feature changes
      * @param {object} frame - given frame information to be used for any feature changes
      */
-    update(dt, f) {
+    update(deltaTime, frame) {
         for (const entity of this.registry) {
             this.updatePanel(entity);
         }
@@ -40,7 +38,7 @@ export class PanelSystem extends MRSystem {
     /**
      * @function
      * @description Called when a new entity is added to this system
-     * @param {MREntity} entity - the entity being added.
+     * @param {object} entity - the entity being added.
      */
     onNewEntity(entity) {
         if (entity instanceof MRPanelEntity) {
@@ -51,7 +49,7 @@ export class PanelSystem extends MRSystem {
     /**
      * @function
      * @description used to set the position of an individual panel
-     * @param {MREntity} entity - the entity being added.
+     * @param {object} entity - the entity being updated.
      */
     updatePanel(entity) {
         const rect = entity.getBoundingClientRect();

--- a/src/core/componentSystems/PhysicsSystem.js
+++ b/src/core/componentSystems/PhysicsSystem.js
@@ -270,7 +270,7 @@ export class PhysicsSystem extends MRSystem {
     updateUIBody(entity) {
         this.tempBBox.setFromCenterAndSize(entity.object3D.position, new THREE.Vector3(entity.width, entity.height, 0.002));
 
-        this.tempWorldScale.setFromMatrixScale( (entity instanceof MRPanelEntity) ? entity.panel.matrixWorld : entity.object3D.matrixWorld );
+        this.tempWorldScale.setFromMatrixScale(entity instanceof MRPanelEntity ? entity.panel.matrixWorld : entity.object3D.matrixWorld);
         this.tempBBox.getSize(this.tempSize);
         this.tempSize.multiply(this.tempWorldScale);
 

--- a/src/core/componentSystems/PhysicsSystem.js
+++ b/src/core/componentSystems/PhysicsSystem.js
@@ -205,27 +205,28 @@ export class PhysicsSystem extends MRSystem {
         });
     }
 
-    /**
-     * @function
-     * @param object3D
-     * @param scale
-     * @description Initializes a convexMesh collider from a THREE.js geometry
-     * NOTE: not currently in use until we can sync it with animations
-     * @param {MREntity} entity - the entity being updated
-     */
-    initConvexMeshCollider(object3D, scale) {
-        const positionAttribute = object3D.geometry.getAttribute('position');
-        const vertices = [];
-        for (let i = 0; i < positionAttribute.count; i++) {
-            const vertex = new THREE.Vector3().fromBufferAttribute(positionAttribute, i).multiplyScalar(scale);
-            vertices.push(vertex.toArray());
-        }
+    // /**
+    //  * @function
+    //  * @param object3D
+    //  * @param scale
+    //  * @description Initializes a convexMesh collider from a THREE.js geometry
+    //  * NOTE: not currently in use until we can sync it with animations
+    //  * NOTE: commenting for now until we make sure this works like the other init functions.
+    //  * @param {object} entity - the entity being updated
+    //  */
+    // initConvexMeshCollider(object3D, scale) {
+    //     // const positionAttribute = object3D.geometry.getAttribute('position');
+    //     // const vertices = [];
+    //     // for (let i = 0; i < positionAttribute.count; i++) {
+    //     //     const vertex = new THREE.Vector3().fromBufferAttribute(positionAttribute, i).multiplyScalar(scale);
+    //     //     vertices.push(vertex.toArray());
+    //     // }
 
-        // Convert vertices to a flat Float32Array as required by RAPIER.ConvexHull
-        const verticesFlat = new Float32Array(vertices.flat());
+    //     // // Convert vertices to a flat Float32Array as required by RAPIER.ConvexHull
+    //     // const verticesFlat = new Float32Array(vertices.flat());
 
-        return mrjsUtils.physics.RAPIER.ColliderDesc.convexMesh(verticesFlat);
-    }
+    //     // return mrjsUtils.physics.RAPIER.ColliderDesc.convexMesh(verticesFlat);
+    // }
 
     /**
      * @function

--- a/src/core/componentSystems/SkyBoxSystem.js
+++ b/src/core/componentSystems/SkyBoxSystem.js
@@ -32,7 +32,7 @@ export class SkyBoxSystem extends MRSystem {
     /**
      * @function
      * @description Called when a new entity is added to the scene. Adds said new entity to the style's system registry.
-     * @param {MREntity} entity - the entity being added.
+     * @param {object} entity - the entity being added.
      */
     onNewEntity(entity) {
         if (entity instanceof MRSkyBoxEntity) {

--- a/src/core/componentSystems/TextSystem.js
+++ b/src/core/componentSystems/TextSystem.js
@@ -67,9 +67,9 @@ export class TextSystem extends MRSystem {
     }
 
     /**
-     * @param entity
      * @function
-     * @description The per entity triggered update call.  Handles updating all text items including updates for style and cleaning of content for special characters.
+     * @param {object} entity - the entity that needs to be updated.
+     * @description The per entity triggered update call. Handles updating all text items including updates for style and cleaning of content for special characters.
      */
     _updateSpecificEntity(entity) {
         this.updateStyle(entity);

--- a/src/core/componentSystems/TextSystem.js
+++ b/src/core/componentSystems/TextSystem.js
@@ -100,18 +100,18 @@ export class TextSystem extends MRSystem {
      */
     eventUpdate = () => {
         for (const entity of this.registry) {
-
-            // Add a check in case a user manually 
-            let text = entity instanceof MRTextFieldEntity || entity instanceof MRTextAreaEntity
-                ? entity.hiddenInput.value
-                : // troika honors newlines/white space
-                  // we want to mimic h1, p, etc which do not honor these values
-                  // so we have to clean these from the text
-                  // ref: https://github.com/protectwise/troika/issues/289#issuecomment-1841916850
-                  entity.textContent
-                      .replace(/(\n)\s+/g, '$1')
-                      .replace(/(\r\n|\n|\r)/gm, ' ')
-                      .trim();
+            // Add a check in case a user manually
+            let text =
+                entity instanceof MRTextFieldEntity || entity instanceof MRTextAreaEntity
+                    ? entity.hiddenInput.value
+                    : // troika honors newlines/white space
+                      // we want to mimic h1, p, etc which do not honor these values
+                      // so we have to clean these from the text
+                      // ref: https://github.com/protectwise/troika/issues/289#issuecomment-1841916850
+                      entity.textContent
+                          .replace(/(\n)\s+/g, '$1')
+                          .replace(/(\r\n|\n|\r)/gm, ' ')
+                          .trim();
 
             let textContentChanged = entity.textObj.text != text;
 
@@ -122,7 +122,7 @@ export class TextSystem extends MRSystem {
                 this._updateSpecificEntity(entity);
             }
         }
-    }
+    };
 
     /**
      * @function

--- a/src/core/entities/MRDivEntity.js
+++ b/src/core/entities/MRDivEntity.js
@@ -54,7 +54,7 @@ export class MRDivEntity extends MREntity {
         const rect = this.getBoundingClientRect();
 
         if (mrjsUtils.xr.isPresenting) {
-            return (rect.height / mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION);
+            return rect.height / mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
         }
         return (rect.height / global.appHeight) * global.viewPortHeight;
     }
@@ -68,7 +68,7 @@ export class MRDivEntity extends MREntity {
         const rect = this.getBoundingClientRect();
 
         if (mrjsUtils.xr.isPresenting) {
-            return (rect.width / mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION);
+            return rect.width / mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
         }
         return (rect.width / global.appWidth) * global.viewPortWidth;
     }

--- a/src/core/entities/MRHyperlinkEntity.js
+++ b/src/core/entities/MRHyperlinkEntity.js
@@ -15,6 +15,11 @@ export default class MRHyperlinkEntity extends MRTextEntity {
         this.object3D.name = 'hyperlink';
     }
 
+    /**
+     * @function
+     * @description Creates the link object if it's not already created and handles the href and
+     * target attributes.
+     */
     _createLink() {
         if (!this.link) {
             this.link = document.createElement('a');
@@ -23,18 +28,30 @@ export default class MRHyperlinkEntity extends MRTextEntity {
         }
     }
 
+    /**
+     * @function
+     * @description Grabs the href of the link object
+     * @returns {string} the href value
+     */
     get href() {
         this._createLink();
         return this.link.getAttribute('href');
     }
 
+    /**
+     * @function
+     * @description Sets the href of the link object
+     * @param {string} src_str - the new href value
+     */
     set href(src_str) {
         this._createLink();
         this.link.setAttribute('href', src_str);
     }
 
     /**
-     *
+     * @function
+     * @description Callback function of MREntity - makes sure the link object is created and sets up event
+     * listeners for touchstart and click.
      */
     connected() {
         super.connected();

--- a/src/core/entities/MRImageEntity.js
+++ b/src/core/entities/MRImageEntity.js
@@ -21,10 +21,20 @@ export class MRImageEntity extends MRMediaEntity {
         this.object3D.name = 'image';
     }
 
+    /**
+     * @function
+     * @description Gets the width of the internal media object
+     * @returns {number} width - the value of the width
+     */
     get mediaWidth() {
         return this.media.width;
     }
 
+    /**
+     * @function
+     * @description Gets the height of the internal media object
+     * @returns {number} height - the value of the height
+     */
     get mediaHeight() {
         return this.media.height;
     }
@@ -38,6 +48,10 @@ export class MRImageEntity extends MRMediaEntity {
         super.connected();
     }
 
+    /**
+     * @function
+     * @description Loads the Media texture of the setup this.media object based on its html source info.
+     */
     loadMediaTexture() {
         mrjsUtils.material
             .loadTextureAsync(this.media.src)

--- a/src/core/entities/MRMediaEntity.js
+++ b/src/core/entities/MRMediaEntity.js
@@ -170,14 +170,14 @@ export class MRMediaEntity extends MRDivEntity {
             // to make sure that texture is set properly
             this.object3D.material.visible = true;
             this.object3D.material.needsUpdate = true;
-        }
+        };
 
         const _hideMainMediaMesh = () => {
             // to parallel the '_makeSureMainMediaMeshHasTexture' for readability
             // and debugging later on.
             this.object3D.material.visible = false;
             this.object3D.material.needsUpdate = true;
-        }
+        };
 
         let containerWidth = this.parentElement.width;
         let containerHeight = this.parentElement.height;

--- a/src/core/entities/MRMediaEntity.js
+++ b/src/core/entities/MRMediaEntity.js
@@ -49,7 +49,7 @@ export class MRMediaEntity extends MRDivEntity {
 
     /**
      * @function
-     * @description Calculates the width of the media based on the media tag in the shadow root
+     * @description Calculates the width of the MRMedia object
      * @returns {number} - the resolved width
      */
     get width() {
@@ -59,7 +59,7 @@ export class MRMediaEntity extends MRDivEntity {
 
     /**
      * @function
-     * @description Calculates the height of the media based on the media tag in the shadow root
+     * @description Calculates the height of the MRMedia object
      * @returns {number} - the resolved height
      */
     get height() {
@@ -67,14 +67,35 @@ export class MRMediaEntity extends MRDivEntity {
         return height > 0 ? height : super.height;
     }
 
+    /**
+     * @function
+     * @description Calculates the width of the media based on the media tag itself
+     * This function will error if called directly as an MRMedia item. Made to be overridden
+     * by children.
+     * @returns {number} - the resolved height
+     */
     get mediaWidth() {
         mrjsUtils.error.emptyParentFunction();
+        return null;
     }
 
+    /**
+     * @function
+     * @description Calculates the height of the media based on the media tag itself
+     * This function will error if called directly as an MRMedia item. Made to be overridden
+     * by children.
+     * @returns {number} - the resolved height
+     */
     get mediaHeight() {
         mrjsUtils.error.emptyParentFunction();
+        return null;
     }
 
+    /**
+     * @function
+     * @description Creates the Media Plane Geometry used to draw the Image,Video,etc
+     * This is a separate object to allow for common css styling such as 'contain' and 'scale-down'.
+     */
     generateNewMediaPlaneGeometry() {
         if (this.object3D.geometry !== undefined) {
             this.object3D.geometry.dispose();
@@ -82,6 +103,12 @@ export class MRMediaEntity extends MRDivEntity {
         this.object3D.geometry = mrjsUtils.geometry.UIPlane(this.width, this.height, this.borderRadii, 18);
     }
 
+    /**
+     * @function
+     * @description Loads the associated media into 3D based on its html properties.
+     * This function will error if called directly as an MRMedia item. Made to be overridden
+     * by children.
+     */
     loadMediaTexture() {
         mrjsUtils.error.emptyParentFunction();
     }

--- a/src/core/entities/MRModelEntity.js
+++ b/src/core/entities/MRModelEntity.js
@@ -92,13 +92,13 @@ export class MRModelEntity extends MRDivEntity {
 
             this.loaded = true;
 
-            this.traverseObjects(object => {
+            this.traverseObjects((object) => {
                 if (object.isMesh) {
                     object.renderOrder = 3;
                     object.receiveShadow = true;
                     object.castShadow = true;
                 }
-            })
+            });
 
             this.onLoad();
 

--- a/src/core/entities/MRPanelEntity.js
+++ b/src/core/entities/MRPanelEntity.js
@@ -14,17 +14,6 @@ import { mrjsUtils } from 'mrjs';
  */
 export class MRPanelEntity extends MRDivEntity {
     /**
-     *
-     */
-    get height() {
-        let result = this.getBoundingClientRect().height;
-
-        if (mrjsUtils.xr.isPresenting) {
-            result = (result / window.screen.height) * mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
-        }
-        return (result / global.appHeight) * global.viewPortHeight;
-    }
-    /**
      * @class
      * @description Constructor for the main Panel. Sets up all the relevant object3D and window information. Includes information necessary for proper scrolling usage.
      */
@@ -44,6 +33,20 @@ export class MRPanelEntity extends MRDivEntity {
         this.delta = 0;
 
         this.momentumTimeout;
+    }
+
+    /**
+     * @function
+     * @description Gets the height of the current panel in 2D or 3D space (depending on the xr user state)
+     * @returns {number} height - the calcualted height value
+     */
+    get height() {
+        let result = this.getBoundingClientRect().height;
+
+        if (mrjsUtils.xr.isPresenting) {
+            result = (result / window.screen.height) * mrjsUtils.display.VIRTUAL_DISPLAY_RESOLUTION;
+        }
+        return (result / global.appHeight) * global.viewPortHeight;
     }
 
     /**

--- a/src/core/entities/MRTextAreaEntity.js
+++ b/src/core/entities/MRTextAreaEntity.js
@@ -111,7 +111,7 @@ export class MRTextAreaEntity extends MRTextInputEntity {
 
     /**
      * Handles keydown events for scrolling and cursor navigation.
-     * @param event
+     * @param {event} event - the keydown event
      */
     handleKeydown(event) {
         const { keyCode } = event;

--- a/src/core/entities/MRTextAreaEntity.js
+++ b/src/core/entities/MRTextAreaEntity.js
@@ -12,6 +12,9 @@ import { MRTextInputEntity } from 'mrjs/core/entities/MRTextInputEntity';
  * @augments MRTextInputEntity
  */
 export class MRTextAreaEntity extends MRTextInputEntity {
+    /**
+     * @class
+     */
     constructor() {
         super();
         // Define additional properties for handling multiline text and scrolling
@@ -34,6 +37,9 @@ export class MRTextAreaEntity extends MRTextInputEntity {
         }
     }
 
+    /**
+     *
+     */
     createHiddenInputElement() {
         const inputElement = document.createElement('textarea');
         inputElement.style.position = 'absolute';
@@ -45,6 +51,9 @@ export class MRTextAreaEntity extends MRTextInputEntity {
         this.hiddenInput = inputElement;
     }
 
+    /**
+     *
+     */
     fillInHiddenInputElementWithUserData() {
         // name: The name associated with the <textarea> for form submission and backend processing.
         this.hiddenInput.name = this.getAttribute('name') ?? this.defaults.name;
@@ -77,6 +86,9 @@ export class MRTextAreaEntity extends MRTextInputEntity {
         
     }
 
+    /**
+     *
+     */
     updateTextDisplay() {
         // Determine the maximum number of characters per line based on renderable area (example given)
         const maxCharsPerLine = 50; // This should be dynamically calculated
@@ -103,6 +115,7 @@ export class MRTextAreaEntity extends MRTextInputEntity {
 
     /**
      * Handles keydown events for scrolling and cursor navigation.
+     * @param event
      */
     handleKeydown(event) {
         const { keyCode } = event;
@@ -162,6 +175,9 @@ export class MRTextAreaEntity extends MRTextInputEntity {
     // This is useful for things like cursor positioning, etc.
      _textCharWidth = 0;
 
+    /**
+     *
+     */
     updateCursorPosition() {
         // set maxWidth to this.background's width property.
         this.textObj.maxWidth = this.width;

--- a/src/core/entities/MRTextAreaEntity.js
+++ b/src/core/entities/MRTextAreaEntity.js
@@ -21,10 +21,10 @@ export class MRTextAreaEntity extends MRTextInputEntity {
         this.lineHeight = 1.2; // Default line height, can be adjusted as needed
         this.scrollOffset = 0; // The vertical scroll position
         this.maxVisibleLines = 10; // Maximum number of lines visible without scrolling
-        this.object3D.name = 'textArea'
+        this.object3D.name = 'textArea';
 
         this.defaults = {
-            name : 'mr-textarea',
+            name: 'mr-textarea',
             rows: '...',
             cols: '...',
             placeholder: '',
@@ -33,8 +33,8 @@ export class MRTextAreaEntity extends MRTextInputEntity {
             maxLength: '...',
             wrap: '...',
             overflowWrap: 'normal',
-            whiteSpace: 'normal'
-        }
+            whiteSpace: 'normal',
+        };
     }
 
     /**
@@ -79,11 +79,7 @@ export class MRTextAreaEntity extends MRTextInputEntity {
      * Overrides the connected method to include setup for handling multiline text.
      */
     connected() {
-        
-
         super.connected();
-
-        
     }
 
     /**
@@ -92,16 +88,16 @@ export class MRTextAreaEntity extends MRTextInputEntity {
     updateTextDisplay() {
         // Determine the maximum number of characters per line based on renderable area (example given)
         const maxCharsPerLine = 50; // This should be dynamically calculated
-        
-        const lines = this.hiddenInput.value.split('\n').map(line => {
+
+        const lines = this.hiddenInput.value.split('\n').map((line) => {
             // Truncate or split lines here based on maxCharsPerLine if implementing horizontal scrolling
             return line.substring(0, maxCharsPerLine);
         });
-        
+
         // Existing logic to determine visibleLines based on scrollOffset and maxVisibleLines
         const visibleLines = lines.slice(this.scrollOffset, this.scrollOffset + this.maxVisibleLines);
         const visibleText = visibleLines.join('\n');
-        
+
         this.textObj.text = visibleText;
         // console.log('text updated: ', this.textObj.text);
 
@@ -173,7 +169,7 @@ export class MRTextAreaEntity extends MRTextInputEntity {
     // actual 3d space a character is expected to take up.
     //
     // This is useful for things like cursor positioning, etc.
-     _textCharWidth = 0;
+    _textCharWidth = 0;
 
     /**
      *
@@ -184,8 +180,8 @@ export class MRTextAreaEntity extends MRTextInputEntity {
         this.textObj.maxHeight = this.height;
         // calculate the textObj's width for the cursorCalculatedStartingPosition
         if (this._cursorCalculatedStartingPosition.x == 0 && this._cursorCalculatedStartingPosition.y == 0) {
-            this._cursorCalculatedStartingPosition.x = -1.0 * this.textObj.maxWidth / 2;
-            this._cursorCalculatedStartingPosition.y = 1.0 * this.textObj.maxHeight / 2 - this._cursorHeight / 2;
+            this._cursorCalculatedStartingPosition.x = (-1.0 * this.textObj.maxWidth) / 2;
+            this._cursorCalculatedStartingPosition.y = (1.0 * this.textObj.maxHeight) / 2 - this._cursorHeight / 2;
         }
 
         // Calculate the cursor position within the hiddenInput
@@ -212,23 +208,23 @@ export class MRTextAreaEntity extends MRTextInputEntity {
         const cursorXPosition = currentLineText.length * 0.005;
         // console.log('------done')
         const cursorYPosition = -(visibleLinesStartIndex * (this.lineHeight * this._textCharHeight) * this.textObj.fontSize);
-        
+
         const cursorDebugObj = {
-            cursorIndex : cursorIndex,
-            textBeforeCursor : textBeforeCursor,
-            linesBeforeCursor : linesBeforeCursor,
-            numberOfLines : numberOfLines,
-            currentLineText : currentLineText,
-            visibleLinesStartIndex : visibleLinesStartIndex,
-            lines : lines,
-            cursorXPosition : cursorXPosition,
-            cursorYPosition : cursorYPosition
+            cursorIndex: cursorIndex,
+            textBeforeCursor: textBeforeCursor,
+            linesBeforeCursor: linesBeforeCursor,
+            numberOfLines: numberOfLines,
+            currentLineText: currentLineText,
+            visibleLinesStartIndex: visibleLinesStartIndex,
+            lines: lines,
+            cursorXPosition: cursorXPosition,
+            cursorYPosition: cursorYPosition,
         };
 
         // console.log('troika obj:', this.textObj);
         // this.printCurrentTextDebugInfo();
         // console.log('cursor debug obj:', cursorDebugObj);
-        
+
         // Update the cursor's 3D position
         if (this.cursor) {
             this.cursor.position.x = this._cursorCalculatedStartingPosition.x + cursorXPosition;
@@ -236,7 +232,6 @@ export class MRTextAreaEntity extends MRTextInputEntity {
             this.cursor.visible = true;
         }
     }
-
 }
 
 customElements.get('mr-textarea') || customElements.define('mr-textarea', MRTextAreaEntity);

--- a/src/core/entities/MRTextEntity.js
+++ b/src/core/entities/MRTextEntity.js
@@ -53,7 +53,6 @@ export class MRTextEntity extends MRDivEntity {
      * @function
      * @description Triggers a system run to update text specifically for the entity calling it. Useful when it's not an overall scene event and for cases where
      * relying on an overall scene or all items to update isnt beneficial.
-     * @returns {number} - height of the 3D object.
      */
     triggerTextStyleUpdate() {
         this.dispatchEvent(new CustomEvent('trigger-text-style-update', { detail: this, bubbles: true }));
@@ -61,7 +60,7 @@ export class MRTextEntity extends MRDivEntity {
 
     /**
      *
-     * @param textObj
+     * @param {object} textObj - the textobj
      */
     printCurrentTextDebugInfo(textObj) {
         if (!textObj) {

--- a/src/core/entities/MRTextEntity.js
+++ b/src/core/entities/MRTextEntity.js
@@ -50,15 +50,19 @@ export class MRTextEntity extends MRDivEntity {
     }
 
         /**
-     * @function
-     * @description Triggers a system run to update text specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
-     * relying on an overall scene or all items to update isnt beneficial.
-     * @returns {number} - height of the 3D object.
-     */
+         * @function
+         * @description Triggers a system run to update text specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
+         * relying on an overall scene or all items to update isnt beneficial.
+         * @returns {number} - height of the 3D object.
+         */
     triggerTextStyleUpdate() {
         this.dispatchEvent(new CustomEvent('trigger-text-style-update', { detail: this, bubbles: true }));
     }
 
+    /**
+     *
+     * @param textObj
+     */
     printCurrentTextDebugInfo(textObj) {
         if (! textObj) {
             const textDebugObj = {

--- a/src/core/entities/MRTextEntity.js
+++ b/src/core/entities/MRTextEntity.js
@@ -49,12 +49,12 @@ export class MRTextEntity extends MRDivEntity {
         this.triggerTextStyleUpdate();
     }
 
-        /**
-         * @function
-         * @description Triggers a system run to update text specifically for the entity calling it. Useful when it's not an overall scene event and for cases where 
-         * relying on an overall scene or all items to update isnt beneficial.
-         * @returns {number} - height of the 3D object.
-         */
+    /**
+     * @function
+     * @description Triggers a system run to update text specifically for the entity calling it. Useful when it's not an overall scene event and for cases where
+     * relying on an overall scene or all items to update isnt beneficial.
+     * @returns {number} - height of the 3D object.
+     */
     triggerTextStyleUpdate() {
         this.dispatchEvent(new CustomEvent('trigger-text-style-update', { detail: this, bubbles: true }));
     }
@@ -64,62 +64,62 @@ export class MRTextEntity extends MRDivEntity {
      * @param textObj
      */
     printCurrentTextDebugInfo(textObj) {
-        if (! textObj) {
+        if (!textObj) {
             const textDebugObj = {
-                anchorX : this.textObj.anchorX,
-                anchorY : this.textObj.anchorY,
-                colorRanges : this.textObj.colorRanges,
-                curveRadius : this.textObj.curveRadius,
-                customDepthMaterials : this.textObj.customDepthMaterials,
-                customDistanceMaterials : this.textObj.customDistanceMaterials,
-                direction : this.textObj.direction,
-                font : this.textObj.font,
-                fontSize : this.textObj.fontSize,
-                fontStyle : this.textObj.fontStyle,
-                fontWeight : this.textObj.fontWeight,
-                glyphGeometryDetail : this.textObj.glyphGeometryDetail,
-                lang : this.textObj.lang,
-                letterSpacing : this.textObj.letterSpacing,
-                lineHeight : this.textObj.lineHeight,
-                material : this.textObj.material,
-                maxWidth : this.textObj.maxWidth,
-                overflowWrap : this.textObj.overflowWrap,
-                sdfGlyphSize : this.textObj.sdfGlyphSize,
-                text : this.textObj.text,
-                textAlign : this.textObj.textAlign,
-                textIndent : this.textObj.textIndent,
-                textRenderInfo : this.textObj.textRenderInfo,
-                whiteSpace : this.textObj.whiteSpace,
+                anchorX: this.textObj.anchorX,
+                anchorY: this.textObj.anchorY,
+                colorRanges: this.textObj.colorRanges,
+                curveRadius: this.textObj.curveRadius,
+                customDepthMaterials: this.textObj.customDepthMaterials,
+                customDistanceMaterials: this.textObj.customDistanceMaterials,
+                direction: this.textObj.direction,
+                font: this.textObj.font,
+                fontSize: this.textObj.fontSize,
+                fontStyle: this.textObj.fontStyle,
+                fontWeight: this.textObj.fontWeight,
+                glyphGeometryDetail: this.textObj.glyphGeometryDetail,
+                lang: this.textObj.lang,
+                letterSpacing: this.textObj.letterSpacing,
+                lineHeight: this.textObj.lineHeight,
+                material: this.textObj.material,
+                maxWidth: this.textObj.maxWidth,
+                overflowWrap: this.textObj.overflowWrap,
+                sdfGlyphSize: this.textObj.sdfGlyphSize,
+                text: this.textObj.text,
+                textAlign: this.textObj.textAlign,
+                textIndent: this.textObj.textIndent,
+                textRenderInfo: this.textObj.textRenderInfo,
+                whiteSpace: this.textObj.whiteSpace,
             };
             console.log('textDebugInfo: ', textDebugObj);
             return;
         }
 
         const textDebugObj = {
-            anchorX : textObj.anchorX,
-            anchorY : textObj.anchorY,
-            colorRanges : textObj.colorRanges,
-            curveRadius : textObj.curveRadius,
-            customDepthMaterials : textObj.customDepthMaterials,
-            customDistanceMaterials : textObj.customDistanceMaterials,
-            direction : textObj.direction,
-            font : textObj.font,
-            fontSize : textObj.fontSize,
-            fontStyle : textObj.fontStyle,
-            fontWeight : textObj.fontWeight,
-            glyphGeometryDetail : textObj.glyphGeometryDetail,
-            lang : textObj.lang,
-            letterSpacing : textObj.letterSpacing,
-            lineHeight : textObj.lineHeight,
-            material : textObj.material,
-            maxWidth : textObj.maxWidth,
-            overflowWrap : textObj.overflowWrap,
-            sdfGlyphSize : textObj.sdfGlyphSize,
-            text : textObj.text,
-            textAlign : textObj.textAlign,
-            textIndent : textObj.textIndent,
-            textRenderInfo : textObj.textRenderInfo,
-            whiteSpace : textObj.whiteSpace,
+            anchorX: textObj.anchorX,
+            anchorY: textObj.anchorY,
+            colorRanges: textObj.colorRanges,
+            curveRadius: textObj.curveRadius,
+            customDepthMaterials: textObj.customDepthMaterials,
+            customDistanceMaterials: textObj.customDistanceMaterials,
+            direction: textObj.direction,
+            font: textObj.font,
+            fontSize: textObj.fontSize,
+            fontStyle: textObj.fontStyle,
+            fontWeight: textObj.fontWeight,
+            glyphGeometryDetail: textObj.glyphGeometryDetail,
+            lang: textObj.lang,
+            letterSpacing: textObj.letterSpacing,
+            lineHeight: textObj.lineHeight,
+            material: textObj.material,
+            maxWidth: textObj.maxWidth,
+            overflowWrap: textObj.overflowWrap,
+            sdfGlyphSize: textObj.sdfGlyphSize,
+            text: textObj.text,
+            textAlign: textObj.textAlign,
+            textIndent: textObj.textIndent,
+            textRenderInfo: textObj.textRenderInfo,
+            whiteSpace: textObj.whiteSpace,
         };
         console.log('textDebugInfo: ', textDebugObj);
     }

--- a/src/core/entities/MRTextFieldEntity.js
+++ b/src/core/entities/MRTextFieldEntity.js
@@ -20,11 +20,17 @@ export class MRTextFieldEntity extends MRTextInputEntity {
         this.wrapper.innerHTML = '<slot></slot>';
     }
 
+    /**
+     *
+     */
     createHiddenInputElement() {
         this.hiddenInput = document.createElement('input');
         this.hiddenInput.setAttribute('type', 'text');
     }
 
+    /**
+     *
+     */
     updateTextDisplay() {
         // Determine the maximum number of characters per line based on renderable area (example given)
         const maxCharsPerLine = 50; // This should be dynamically calculated
@@ -36,6 +42,7 @@ export class MRTextFieldEntity extends MRTextInputEntity {
 
     /**
      * Handles keydown events for scrolling and cursor navigation.
+     * @param event
      */
     handleKeydown(event) {
         const { keyCode } = event;

--- a/src/core/entities/MRTextFieldEntity.js
+++ b/src/core/entities/MRTextFieldEntity.js
@@ -34,7 +34,7 @@ export class MRTextFieldEntity extends MRTextInputEntity {
     updateTextDisplay() {
         // Determine the maximum number of characters per line based on renderable area (example given)
         const maxCharsPerLine = 50; // This should be dynamically calculated
-        
+
         this.textObj.text = visibleText;
 
         this.updateCursorPosition();
@@ -73,7 +73,6 @@ export class MRTextFieldEntity extends MRTextInputEntity {
      */
     updateCursorPosition() {
         // to be resolved in future implementation.
-
         // const end = this.hiddenInput.selectionStart > 0 ? this.hiddenInput.selectionStart : 1;
         // const selectBox = getSelectionRects(this.textObj.textRenderInfo, 0, end).pop();
         // if (!selectBox || isNaN(selectBox.left)) {
@@ -87,7 +86,7 @@ export class MRTextFieldEntity extends MRTextInputEntity {
         //     }
         //     this.cursor.position.setY(selectBox.bottom / 2); //+ this.textObj.fontSize / 2); <--keep here for now, might bring it back
         // }
-    };
+    }
 }
 
 customElements.get('mr-textfield') || customElements.define('mr-textfield', MRTextFieldEntity);

--- a/src/core/entities/MRTextFieldEntity.js
+++ b/src/core/entities/MRTextFieldEntity.js
@@ -42,7 +42,7 @@ export class MRTextFieldEntity extends MRTextInputEntity {
 
     /**
      * Handles keydown events for scrolling and cursor navigation.
-     * @param event
+     * @param {event} event - keydown event
      */
     handleKeydown(event) {
         const { keyCode } = event;

--- a/src/core/entities/MRTextInputEntity.js
+++ b/src/core/entities/MRTextInputEntity.js
@@ -19,18 +19,30 @@ export class MRTextInputEntity extends MRTextEntity {
         this.attachShadow({ mode: 'open' });
     }
 
+    /**
+     *
+     */
     get value() {
         return this.hiddenInput.value;
     }
 
+    /**
+     *
+     */
     set value(val) {
         this.hiddenInput.value = val;
     }
 
+    /**
+     *
+     */
     createHiddenInputElement() {
         mrjsUtils.error.emptyParentFunction();
     }
 
+    /**
+     *
+     */
     fillInHiddenInputElementWithUserData() {
         mrjsUtils.error.emptyParentFunction();
     }
@@ -51,6 +63,9 @@ export class MRTextInputEntity extends MRTextEntity {
         this.triggerTextStyleUpdate();
     }
 
+    /**
+     *
+     */
     _createCursor() {
         this._cursorWidth = 0.0015;
         this._cursorHeight = 0.02;
@@ -72,14 +87,24 @@ export class MRTextInputEntity extends MRTextEntity {
         mrjsUtils.error.emptyParentFunction();
     };
 
+    /**
+     *
+     * @param event
+     */
     handleKeydown(event) {
         mrjsUtils.error.emptyParentFunction();
     }
 
+    /**
+     *
+     */
     updateTextDisplay() {
         mrjsUtils.error.emptyParentFunction();
     }
 
+    /**
+     *
+     */
     _focus() {
         if (! this.hiddenInput) {
             return;
@@ -102,6 +127,9 @@ export class MRTextInputEntity extends MRTextEntity {
         console.log('hi7');
     }
 
+    /**
+     *
+     */
     setupEventListeners() {
         // Since we want the text input children to be able
         // to override the parent function event triggers,

--- a/src/core/entities/MRTextInputEntity.js
+++ b/src/core/entities/MRTextInputEntity.js
@@ -20,7 +20,7 @@ export class MRTextInputEntity extends MRTextEntity {
     }
 
     /**
-     *
+     * @returns {string} value - the value of the current text input
      */
     get value() {
         return this.hiddenInput.value;
@@ -89,7 +89,7 @@ export class MRTextInputEntity extends MRTextEntity {
 
     /**
      *
-     * @param event
+     * @param {event} event - the keydown event
      */
     handleKeydown(event) {
         mrjsUtils.error.emptyParentFunction();

--- a/src/core/entities/MRTextInputEntity.js
+++ b/src/core/entities/MRTextInputEntity.js
@@ -85,7 +85,7 @@ export class MRTextInputEntity extends MRTextEntity {
      */
     updateCursorPosition() {
         mrjsUtils.error.emptyParentFunction();
-    };
+    }
 
     /**
      *
@@ -106,7 +106,7 @@ export class MRTextInputEntity extends MRTextEntity {
      *
      */
     _focus() {
-        if (! this.hiddenInput) {
+        if (!this.hiddenInput) {
             return;
         }
         console.log('this._focus is hit');
@@ -133,7 +133,7 @@ export class MRTextInputEntity extends MRTextEntity {
     setupEventListeners() {
         // Since we want the text input children to be able
         // to override the parent function event triggers,
-        // separating them into an actual function here 
+        // separating them into an actual function here
         // and calling them manually. This allows us to call
         // super.func() for event functions; otherwise, theyre
         // not accessible.

--- a/src/core/entities/MRVideoEntity.js
+++ b/src/core/entities/MRVideoEntity.js
@@ -39,7 +39,8 @@ export class MRVideoEntity extends MRMediaEntity {
     }
 
     /**
-     *
+     * @function
+     * @description Loads the associated video into 3D based on its html properties.
      */
     loadMediaTexture() {
         mrjsUtils.material
@@ -66,7 +67,9 @@ export class MRVideoEntity extends MRMediaEntity {
     }
 
     /**
-     *
+     * @function
+     * @description Sets the srcObject of the video media (since it uses 'srcObject' instead of 'src' like other items).
+     * @param {string} src - the string to the new source object we want
      */
     set srcObject(src) {
         this.media.srcObject = src;
@@ -85,7 +88,6 @@ export class MRVideoEntity extends MRMediaEntity {
         this.playing = true;
     }
 
-    //pause
     /**
      * @function
      * @description Pauses the video in the shadow root

--- a/src/core/entities/MRVideoEntity.js
+++ b/src/core/entities/MRVideoEntity.js
@@ -20,14 +20,27 @@ export class MRVideoEntity extends MRMediaEntity {
         this.playing = false;
     }
 
+    /**
+     * @function
+     * @description Calculates the width of the video based on the video tag itself
+     * @returns {number} - the resolved width
+     */
     get mediaWidth() {
         return this.media.videoWidth;
     }
 
+    /**
+     * @function
+     * @description Calculates the height of the video based on the video tag itself
+     * @returns {number} - the resolved height
+     */
     get mediaHeight() {
         return this.media.videoHeight;
     }
 
+    /**
+     *
+     */
     loadMediaTexture() {
         mrjsUtils.material
             .loadVideoTextureAsync(this.media)
@@ -52,6 +65,9 @@ export class MRVideoEntity extends MRMediaEntity {
         super.connected();
     }
 
+    /**
+     *
+     */
     set srcObject(src) {
         this.media.srcObject = src;
         // on loadeddata event, update the objectFitDimensions

--- a/src/core/entities/MRVolumeEntity.js
+++ b/src/core/entities/MRVolumeEntity.js
@@ -5,7 +5,7 @@ import { MREntity } from 'mrjs/core/MREntity';
  * @classdesc Representation of a visible region in 3D space. Models and other entities can move
  * throughout the space and leave the space, yet will only be rendered in the visual area of
  * the volume. From a conceptual perspective it is considered a ‘clipping volume’.
- * @augments MRDivEntity
+ * @augments MREntity
  */
 export class MRVolumeEntity extends MREntity {
     /**

--- a/src/core/entities/MRVolumeEntity.js
+++ b/src/core/entities/MRVolumeEntity.js
@@ -1,11 +1,16 @@
 import { MREntity } from 'mrjs/core/MREntity';
 
 /**
- *
+ * @class MRVolumeEntity
+ * @classdesc Representation of a visible region in 3D space. Models and other entities can move
+ * throughout the space and leave the space, yet will only be rendered in the visual area of
+ * the volume. From a conceptual perspective it is considered a ‘clipping volume’.
+ * @augments MRDivEntity
  */
 export class MRVolumeEntity extends MREntity {
     /**
-     *
+     * @class
+     * @description Creates the volume as a base THREE.js object3D
      */
     constructor() {
         super();
@@ -14,7 +19,8 @@ export class MRVolumeEntity extends MREntity {
     }
 
     /**
-     *
+     * @function
+     * @description Callback function of MREntity - handles creating clipping geometry around the entire volume for visible restrictions.
      */
     connected() {
         this.clipping = new MRClippingGeometry(new THREE.BoxGeometry(1, 1, 1));

--- a/src/core/entities/MRVolumeEntity.js
+++ b/src/core/entities/MRVolumeEntity.js
@@ -1,12 +1,21 @@
 import { MREntity } from 'mrjs/core/MREntity';
 
+/**
+ *
+ */
 export class MRVolumeEntity extends MREntity {
+    /**
+     *
+     */
     constructor() {
         super();
         this.volume = new THREE.Object3D();
         this.object3D.add(this.volume);
     }
 
+    /**
+     *
+     */
     connected() {
         this.clipping = new MRClippingGeometry(new THREE.BoxGeometry(1, 1, 1));
         this.ignoreStencil = true;

--- a/src/core/user/MRHand.js
+++ b/src/core/user/MRHand.js
@@ -61,9 +61,8 @@ export class MRHand {
     /**
      * @class
      * @description Constructor for the MRHand class object. Setups up all attributes for MRHand including physics, mouse/cursor information, hand tracking and state, and model
-     * information.
      * @param {object} handedness - enum for the `left`` or `right` hand.
-     * @param {object} app - the current MRApp that contains the scene for the hand.
+     * @param {object} scene - the threejs scene object with information from the MRApp.
      */
     constructor(handedness, scene) {
         this.handedness = handedness;
@@ -108,7 +107,6 @@ export class MRHand {
     /**
      * @function
      * @description Initializes the physics bodies that the hand represents. Useful for collision detection and UX interactions in MR space.
-     * @param {object} scene - the current scene.
      */
     initPhysicsBodies() {
         for (const joint of joints) {

--- a/src/core/user/MRUser.js
+++ b/src/core/user/MRUser.js
@@ -1,5 +1,8 @@
 import { MRHand } from 'mrjs/core/user/MRHand';
 
+/**
+ * @class MRUser
+ */
 export default class MRUser {
     forward = new THREE.Object3D();
 
@@ -11,6 +14,11 @@ export default class MRUser {
         left: null,
         right: null,
     };
+    /**
+     * Constructor for the MRUser class, sets up the camera, hands, and spotlight information.
+     * @param {object} camera - the threejs camera to be used as the user's pov.
+     * @param {object} scene - the threejs scene in which the user will be immersed.
+     */
     constructor(camera, scene) {
         this.camera = camera;
 
@@ -34,6 +42,10 @@ export default class MRUser {
         this.spotLightScale = 1;
     }
 
+    /**
+     * Initializes the spotlight associated with the user's pov.
+     * @returns {object} spotlight - the spotlight to be used.
+     */
     initSpotlight() {
         this.spotlight = new THREE.Mesh(new THREE.CircleGeometry(1.3, 64), new THREE.MeshBasicMaterial());
         this.spotlight.material.colorWrite = false;
@@ -43,6 +55,9 @@ export default class MRUser {
         return this.spotlight;
     }
 
+    /**
+     * The update function for a user, its spotlight, and its hands.
+     */
     update() {
         this.hands.left.update();
         this.hands.right.update();

--- a/src/dataManagers/MRPlaneManager.js
+++ b/src/dataManagers/MRPlaneManager.js
@@ -10,8 +10,9 @@ const PLANE_LABELS = ['floor', 'wall', 'ceiling', 'table', 'desk', 'couch', 'doo
  */
 export class MRPlaneManager {
     /**
-     *
-     * @param scene
+     * @class
+     * @param {object} scene - the MRApp's threejs scene object
+     * @param {boolean} occlusion - whether or not the MRPlaneManager should make the planes visible or not
      */
     constructor(scene, occlusion) {
         // TODO: add app level controls for:
@@ -101,6 +102,14 @@ export class MRPlaneManager {
         });
     }
 
+    /**
+     * @function
+     * @description Initializes the MRPlane for this.currentPlanes at the 'plane' key
+     * @param {object} plane - the map key of this.currentPlanes for which we want to initPlane to fill in its value.
+     * @param {number} width - expected width of the new MRPlane
+     * @param {number} height - expected height of the new MRPlane
+     * @returns {object} MRPlane - the MRPlane object that was initialized by this function.
+     */
     initPlane(plane, width, height) {
         let mrPlane = new MRPlane();
 
@@ -135,6 +144,12 @@ export class MRPlaneManager {
         return mrPlane;
     }
 
+    /**
+     * @function
+     * @description Removes the MRPlane from the scene and removes the plane object from the currentPlanes map.
+     * @param {object} plane - plane object associated with this specific MRPlane in the scene
+     * @param {object} mrplane - the specific MRPlane object being removed from the scene
+     */
     removePlane(plane, mrplane) {
         mrplane.mesh.geometry.dispose();
         mrplane.mesh.material.dispose();
@@ -148,8 +163,8 @@ export class MRPlaneManager {
 
     /**
      * @function
-     * @description initializes the physics body of an MR Plane
-     * @param plane
+     * @description Initializes the physics body of an MRPlane
+     * @returns {object} body - the created rigid body for the plane
      */
     initPhysicsBody() {
         const rigidBodyDesc = mrjsUtils.physics.RAPIER.RigidBodyDesc.kinematicPositionBased().setTranslation(...this.tempPosition);

--- a/src/extras/Refractor.js
+++ b/src/extras/Refractor.js
@@ -1,6 +1,14 @@
 import { Color, Matrix4, Mesh, PerspectiveCamera, Plane, Quaternion, ShaderMaterial, UniformsUtils, Vector3, Vector4, WebGLRenderTarget, HalfFloatType } from 'three';
 
+/**
+ *
+ */
 class Refractor extends Mesh {
+    /**
+     *
+     * @param geometry
+     * @param options
+     */
     constructor(geometry, options = {}) {
         super(geometry);
 
@@ -136,6 +144,10 @@ class Refractor extends Mesh {
         // This will update the texture matrix that is used for projective texture mapping in the shader.
         // see: http://developer.download.nvidia.com/assets/gamedev/docs/projective_texture_mapping.pdf
 
+        /**
+         *
+         * @param camera
+         */
         function updateTextureMatrix(camera) {
             // this matrix does range mapping to [ 0, 1 ]
 
@@ -152,6 +164,12 @@ class Refractor extends Mesh {
 
         //
 
+        /**
+         *
+         * @param renderer
+         * @param scene
+         * @param camera
+         */
         function render(renderer, scene, camera) {
             scope.visible = false;
 

--- a/src/extras/Water.js
+++ b/src/extras/Water.js
@@ -9,7 +9,15 @@ import { MRSystem } from '../core/MRSystem';
  *
  */
 
+/**
+ *
+ */
 class Water extends Mesh {
+    /**
+     *
+     * @param geometry
+     * @param options
+     */
     constructor(geometry, options = {}) {
         super(geometry);
 
@@ -103,6 +111,10 @@ class Water extends Mesh {
 
     // functions
 
+    /**
+     *
+     * @param camera
+     */
     updateTextureMatrix(camera) {
         this.textureMatrix.set(0.5, 0.0, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0);
 
@@ -111,6 +123,10 @@ class Water extends Mesh {
         this.textureMatrix.multiply(this.matrixWorld);
     }
 
+    /**
+     *
+     * @param delta
+     */
     updateFlow(delta) {
         this.delta = delta;
         this.config = this.material.uniforms['config'];
@@ -286,12 +302,24 @@ class Water extends Mesh {
     };
 }
 
+/**
+ *
+ */
 class WaterSystem extends MRSystem {
+    /**
+     *
+     * @param water
+     */
     constructor(water) {
         super(false, 1 / water.fps);
         this.water = water;
     }
 
+    /**
+     *
+     * @param dt
+     * @param f
+     */
     update(dt, f) {
         if (this.water.visible) {
             this.water.updateTextureMatrix(this.app.camera);

--- a/src/utils/CSS.js
+++ b/src/utils/CSS.js
@@ -17,12 +17,12 @@ css.domToThree = function (val) {
             switch (valuepair[1]) {
                 case 'px':
                     if (mrjsUtils.xr.isPresenting) {
-                        return (val.split('px')[0] / global.appWidth);
+                        return val.split('px')[0] / global.appWidth;
                     }
                     return (val.split('px')[0] / global.appWidth) * global.viewPortWidth;
                 case '%':
                     if (mrjsUtils.xr.isPresenting) {
-                        return (parseFloat(val) / 100);
+                        return parseFloat(val) / 100;
                     }
                     return (parseFloat(val) / 100) * global.viewPortWidth;
                 default:
@@ -57,7 +57,7 @@ css.pxToThree = function (val) {
     let px = val instanceof String ? val.split('px')[0] : val;
 
     if (mrjsUtils.xr.isPresenting) {
-        return (px / global.appWidth);
+        return px / global.appWidth;
     }
     return (px / global.appWidth) * global.viewPortWidth;
 };

--- a/src/utils/Color.js
+++ b/src/utils/Color.js
@@ -15,10 +15,13 @@ let color = {};
  *      g: number, // Green component (0-255)
  *      b: number, // Blue component (0-255)
  *      a: number  // Alpha component (0-1 for transparency)
- * } 
+ * }
  */
 color.hexToRgba = function (hex) {
-    let r = 0, g = 0, b = 0, a = 1; // Default is black
+    let r = 0,
+        g = 0,
+        b = 0,
+        a = 1; // Default is black
     if (hex.startsWith('#')) {
         hex = hex.substring(1);
     }
@@ -42,7 +45,7 @@ color.hexToRgba = function (hex) {
         b = parseInt(hex.substring(4, 6), 16);
         a = parseInt(hex.substring(6, 8), 16) / 255;
     }
-    return {r, g, b, a};
-}
+    return { r, g, b, a };
+};
 
 export { color };

--- a/src/utils/Display.js
+++ b/src/utils/Display.js
@@ -13,7 +13,7 @@ display.VIRTUAL_DISPLAY_RESOLUTION = 1080; //alert(_VIRTUAL_DISPLAY_RESOLUTION);
 
 /**
  * @function
- * @memberof Display
+ * @memberof display
  * @description Checks whether the user is on mobile or not based on a large list of potential options.
  * @returns {boolean} - returns true if on any mobile devices.
  */

--- a/src/utils/Material.js
+++ b/src/utils/Material.js
@@ -88,7 +88,7 @@ material.loadTextureAsync = function (src) {
 /**
  * @function
  * @memberof material
- * @param {object} src - the html video element whose src contains the path to the data to be loaded
+ * @param {object} video - the html video element whose src contains the path to the data to be loaded
  * @description Function to load the texture asynchronously and return a promise
  * @returns {object} texture - the fully loaded texture
  */

--- a/src/utils/Material.js
+++ b/src/utils/Material.js
@@ -57,7 +57,7 @@ material.setObjectMaterial = function (parent, material) {
     }
     return parent;
 };
- 
+
 /**
  * @function
  * @memberof material

--- a/src/utils/Math.js
+++ b/src/utils/Math.js
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 /**
  * @namespace math
  * @description Useful namespace for helping with Math utility functions including numerical, 3d, etc.

--- a/src/utils/Notify.js
+++ b/src/utils/Notify.js
@@ -12,7 +12,7 @@ let error = {};
  */
 error.emptyParentFunction = function () {
     console.error('Empty parent function was reached; this must be overridden in children.');
-}
+};
 
 /**
  * @function
@@ -21,9 +21,9 @@ error.emptyParentFunction = function () {
  * @description Function helper separated out to console error for when we eventually have a more robust
  * erroring system.
  */
-error.err = function(string) {
+error.err = function (string) {
     console.error(string);
-}
+};
 
 /**
  * @namespace warn
@@ -40,7 +40,7 @@ let warn = {};
  */
 warn.EmptyParentFunction = function () {
     console.warn('Empty parent function was reached, make sure this was overridden in children if more execution was expected.');
-}
+};
 
 /**
  * @function
@@ -49,8 +49,8 @@ warn.EmptyParentFunction = function () {
  * @description Function helper separated out to console warn for when we eventually have a more robust
  * warning system.
  */
-warn.warn = function(string) {
+warn.warn = function (string) {
     console.warn(string);
-}
+};
 
 export { error, warn };

--- a/src/utils/Notify.js
+++ b/src/utils/Notify.js
@@ -16,6 +16,7 @@ error.emptyParentFunction = function () {
 
 /**
  * @function
+ * @param {string} string - string of texted emitted through the console.
  * @memberof error
  * @description Function helper separated out to console error for when we eventually have a more robust
  * erroring system.
@@ -43,6 +44,7 @@ warn.EmptyParentFunction = function () {
 
 /**
  * @function
+ * @param {string} string - string of texted emitted through the console.
  * @memberof warn
  * @description Function helper separated out to console warn for when we eventually have a more robust
  * warning system.

--- a/src/utils/String.js
+++ b/src/utils/String.js
@@ -96,7 +96,7 @@ string.vectorToString = function (arr) {
         }
     }
     return str;
-}
+};
 
 /**
  * @function

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -16,7 +16,7 @@ import { js } from './JS.js';
 import { material } from './Material.js';
 import { math } from './Math.js';
 import { model } from './Model.js';
-import { error, warn } from './Notify.js'
+import { error, warn } from './Notify.js';
 import { physics } from './Physics.js';
 import { string } from './String.js';
 import { xr } from './XR.js';


### PR DESCRIPTION
## Notes

Noodling on an issue with #546 so did this to give brain some background time

All items were fully updated except for those in `MRText...` as those will be handled by the change from #546 - for now they were setup just to have an implementation that doesnt create warnings

This also removes the lint check for files in `Extras` as those are outside files we're importing and maintaining jsdocs for it isnt worth it long term

This also includes a pretter-fix pass

------------

## Required to Merge

- [ ] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- [ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.
- [ ] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- [ ] **BREAKING CHANGE**
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: *#pr*
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
