### PR TITLE
fix dependabot.yml path for node modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: npm
-    directory: "/javascript"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Linking

Fixes #627 

## Problem

threejs is out of date and we dont notice / arent prompted properly

## Solution

noticed the path was wrong in the dependabot

### Breaking Change

nope

## Notes

this should fix it - if not, i'll check back in a week to see if it triggers properly

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- ~~[ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected~~
- ~~[ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.~~
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- ~~[ ] **BREAKING CHANGE**~~
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: *#pr*
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
