### PR TITLE
fix typo in handling camera startPos

### DIFF
--- a/dist/mr.js
+++ b/dist/mr.js
@@ -1382,7 +1382,7 @@ eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpac
 /******/ 				var scripts = document.getElementsByTagName("script");
 /******/ 				if(scripts.length) {
 /******/ 					var i = scripts.length - 1;
-/******/ 					while (i > -1 && (!scriptUrl || !/^http(s?):/.test(scriptUrl))) scriptUrl = scripts[i--].src;
+/******/ 					while (i > -1 && !scriptUrl) scriptUrl = scripts[i--].src;
 /******/ 				}
 /******/ 			}
 /******/ 		}

--- a/src/core/MRApp.js
+++ b/src/core/MRApp.js
@@ -390,7 +390,7 @@ export class MRApp extends MRElement {
     initCamera = () => {
         const cameraOptionsString = this.dataset.camera ?? '';
         if (cameraOptionsString) {
-            Object.assign(this.cameraOptions, mrjsUtils.string.stringToJson(this.cameraOptionString) ?? {});
+            Object.assign(this.cameraOptions, mrjsUtils.string.stringToJson(cameraOptionsString) ?? {});
         }
 
         global.appWidth = this.appWidth;
@@ -418,16 +418,13 @@ export class MRApp extends MRElement {
 
         let posUpdated = false;
         if (this.cameraOptions.hasOwnProperty('startPos')) {
-            const startPosString = comp.startPos;
-            if (startPosString) {
-                const startPosArray = startPosString.split(' ').map(parseFloat);
-                if (startPosArray.length === 3) {
-                    const [x, y, z] = startPosArray;
-                    this.camera.position.set(x, y, z);
-                    posUpdated = true;
-                } else {
-                    console.error('Invalid camera starting position format. Please provide "x y z".');
-                }
+            const startPos = this.cameraOptions.startPos;
+            if (startPos.length === 3) {
+                const [x, y, z] = startPos;
+                this.camera.position.set(x, y, z);
+                posUpdated = true;
+            } else {
+                console.error('Invalid camera starting position format. Please provide "x y z".');
             }
         }
         if (!posUpdated) {


### PR DESCRIPTION
## Linking

related to https://discord.com/channels/1137890872688660500/1219366027545149462/1243331608048828446

## Problem

startPos doesnt work

## Solution

fix the typo

### Breaking Change

X
## Notes

X
------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- ~~[ ] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected~~
- [x] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.

camera example before:
<img width="1297" alt="Screenshot 2024-05-23 at 4 28 14 PM" src="https://github.com/Volumetrics-io/mrjs/assets/19377312/1c58ff9e-e7a7-4f60-a15b-f98e819f66e8">

camera example after:
<img width="1260" alt="Screenshot 2024-05-23 at 4 27 52 PM" src="https://github.com/Volumetrics-io/mrjs/assets/19377312/e66a281b-bcb1-4c2e-bf2e-4e40a3f871ad">


- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- ~~[ ] **BREAKING CHANGE**~~
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: *#pr*
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
