### PR TITLE
disable dependabot for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
----
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: "daily"
+# ---
+# version: 2
+# updates:
+#   - package-ecosystem: "github-actions"
+#     directory: "/"
+#     schedule:
+#       interval: "weekly"
+#   - package-ecosystem: npm
+#     directory: "/"
+#     schedule:
+#       interval: "daily"


### PR DESCRIPTION
## Linking

related to https://github.com/Volumetrics-io/product/issues/84

## Problem

we keep running the dependabot to catch up on past libs, but MRjs has been on hold for awhile so it's unnecessary pings and runs of our github action space

## Solution

stop running the dependabot for now and turn it back on when it's being edited/updated again

### Breaking Change

nope

## Notes

*Notes and any associated research or links*

------------

## Required to Merge

- [x] **PASS** - all necessary actions must pass (excluding the auto-skipped ones)
- [x] **TEST IN HEADSET** - [main dev-testing-example](https://github.com/Volumetrics-io/mrjs/tree/main/samples/index.html) and any of the other [examples](https://github.com/Volumetrics-io/mrjs/tree/main/samples/examples) still work as expected
- ~~[ ] **VIDEO** - if this pr changes something visually - post a video here of it in headset-MR and/or on desktop (depending on what it affects) for the reviewer to reference.~~
- [x] **TITLE** - make sure the pr's title is updated appropriately as it will be used to name the commit on merge
- ~~[ ] **BREAKING CHANGE**~~
  - **DOCUMENTATION**: This includes any changes to html tags and their components
    - make a pr in the [documentation repo](https://github.com/Volumetrics-io/documentation) that updates the manual docs to match the breaking change
    - link the pr of the documentation repo here: *#pr*
    - that pr must be approved by `@lobau`
  - **SAMPLES/INDEX.HTML**: This includes any changes (html tags or otherwise) that must be done to our landing page submodule as an effect of this pr's updates
    - make a pr in the [mrjs landing page repo](https://github.com/Volumetrics-io/mrjs-landing) that updates the landing page to match the breaking change
    - link the pr of the landing page repo here: *#pr*
    - that pr must be approved by `@hanbollar`
